### PR TITLE
Ctlao/223 reschedule assigned task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.44.3
+
+- Fix reschedule after changing design for lifecycle occurrences
+
 ## 1.44.2
 
 - Fix to prevent duplicate column metadata due to presence of arrays in different stages

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.44.3-reschedule-assigned-task-SNAPSHOT</version>
+	<version>1.44.3</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.44.2</version>
+	<version>1.44.3-reschedule-assigned-task-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/src/main/resources/query/get/lifecycle/reschedule.sparql
+++ b/agent/src/main/resources/query/get/lifecycle/reschedule.sparql
@@ -14,8 +14,7 @@ PREFIX ontoservice: <https://www.theworldavatar.com/kg/ontoservice/>
 SELECT ?start_date ?end_date ?stage ?event
 WHERE {
 
-  ?target_event dc-terms:identifier "[target]" ;
-    cmns-dt:succeeds* ?event .
+  ?event dc-terms:identifier "[target]" .
 
   ?event fibo-fnd-rel-rel:exemplifies ontoservice:OrderReceivedEvent;
     ^cmns-col:comprises ?service_stage .

--- a/agent/src/main/resources/query/get/lifecycle/reschedule.sparql
+++ b/agent/src/main/resources/query/get/lifecycle/reschedule.sparql
@@ -1,27 +1,20 @@
-PREFIX fibo-fnd-rel-rel: <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dc-terms: <http://purl.org/dc/terms/>
 PREFIX cmns-col: <https://www.omg.org/spec/Commons/Collections/>
 PREFIX cmns-dt: <https://www.omg.org/spec/Commons/DatesAndTimes/>
-PREFIX cmns-dsg: <https://www.omg.org/spec/Commons/Designators/>
 PREFIX cmns-pts: <https://www.omg.org/spec/Commons/PartiesAndSituations/>
-PREFIX dc-terms: <http://purl.org/dc/terms/>
-PREFIX fibo-fbc-pas-fpas: <https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/>
-PREFIX fibo-fnd-arr-lif: <https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/>
+PREFIX fibo-fnd-rel-rel: <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/>
 PREFIX fibo-fnd-dt-fd: <https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/>
-PREFIX fibo-fnd-dt-oc: <https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/>
 PREFIX ontoservice: <https://www.theworldavatar.com/kg/ontoservice/>
 
 SELECT ?start_date ?end_date ?stage ?event
 WHERE {
+  ?event dc-terms:identifier "[target]" ;
+         fibo-fnd-rel-rel:exemplifies ontoservice:OrderReceivedEvent ;
+         ^cmns-col:comprises ?service_stage .
 
-  ?event dc-terms:identifier "[target]" .
-
-  ?event fibo-fnd-rel-rel:exemplifies ontoservice:OrderReceivedEvent;
-    ^cmns-col:comprises ?service_stage .
-  
   ?service_stage cmns-dt:succeeds/cmns-pts:holdsDuring/cmns-dt:hasEndDate ?start_date ;
-    cmns-pts:holdsDuring/cmns-dt:hasEndDate ?end_date ;
-    ^cmns-dt:succeeds ?stage .
-                 
-  ?service_stage fibo-fnd-dt-fd:hasSchedule/fibo-fnd-dt-fd:hasRecurrenceInterval/cmns-dt:hasDurationValue "P1D" .
+                 cmns-pts:holdsDuring/cmns-dt:hasEndDate ?end_date ;
+                 ^cmns-dt:succeeds ?stage ;
+                 fibo-fnd-dt-fd:hasSchedule/fibo-fnd-dt-fd:hasRecurrenceInterval/cmns-dt:hasDurationValue "P1D" .
 }

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.44.3-reschedule-assigned-task-SNAPSHOT";
+  private static final String API_VERSION = "1.44.3";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.44.2";
+  private static final String API_VERSION = "1.44.3-reschedule-assigned-task-SNAPSHOT";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.44.2
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.44.3-reschedule-assigned-task-SNAPSHOT
     build:
       context: ..
       target: test

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.44.3-reschedule-assigned-task-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.44.3
     build:
       context: ..
       target: test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.44.2
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.44.3-reschedule-assigned-task-SNAPSHOT
     build:
       context: ..
       target: agent

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.44.3-reschedule-assigned-task-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.44.3
     build:
       context: ..
       target: agent

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.44.3-reschedule-assigned-task-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.44.3",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.44.2",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.44.3-reschedule-assigned-task-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.44.3-reschedule-assigned-task-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.44.3",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.44.2",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.44.3-reschedule-assigned-task-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",


### PR DESCRIPTION
Updated the reschedule query to uniquely target the order received event.

This should fix the bug where an assigned task cannot be rescheduled.