### PR TITLE
Ctlao/283 filter multi event optional properties

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.52.2</version>
+	<version>1.52.3-filter-multi-event-optional-property-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -351,13 +351,19 @@ public class LifecycleTaskService {
       List<ServiceEventFilterQueryManifest> queryManifests = List
           .of(completeQueryStatements, cancelQueryStatements, reportQueryStatements);
 
-      boolean hasAllOptionalFields = queryManifests.stream()
+      // Filter down to manifests that are actually participating (non-empty queries)
+      List<ServiceEventFilterQueryManifest> activeManifests = queryManifests.stream()
+          .filter(manifest -> manifest.query() != null && !manifest.query().trim().isEmpty())
+          .toList();
+
+      // Evaluate structural wrapping types ONLY across the active filters
+      boolean hasAllOptionalFields = !activeManifests.isEmpty() && activeManifests.stream()
           .allMatch(manifest -> manifest.onlyOptionalField() && !manifest.hasActiveFilters);
-      boolean hasAllMinusFields = queryManifests.stream()
+      boolean hasAllMinusFields = !activeManifests.isEmpty() && activeManifests.stream()
           .allMatch(manifest -> manifest.onlyMinusFilter() && !manifest.hasFilterField);
 
-      List<String> nonEmptyQueryStatements = queryManifests.stream()
-          .filter(manifest -> manifest.query() != null && !manifest.query().trim().isEmpty())
+      // Extract the inner clauses safely using the refined global rules
+      List<String> nonEmptyQueryStatements = activeManifests.stream()
           .map(manifest -> {
             if (hasAllOptionalFields) {
               return QueryResource.getClauseContents(manifest.query(), true);
@@ -369,8 +375,14 @@ public class LifecycleTaskService {
           .toList();
       // When only one query meets the criteria, add them directly
       if (nonEmptyQueryStatements.size() == 1) {
-        addFilterQueries += nonEmptyQueryStatements.get(0);
-        // When multiple queries meet the filter/sort criteria
+        String statement = nonEmptyQueryStatements.get(0);
+        if (hasAllOptionalFields) {
+          statement = QueryResource.optional(statement);
+        } else if (hasAllMinusFields) {
+          statement = QueryResource.minus(statement);
+        }
+        addFilterQueries += statement;
+        
       } else if (!nonEmptyQueryStatements.isEmpty()) {
         String[] parsedStatements = nonEmptyQueryStatements.toArray(String[]::new);
         String unionStatement = QueryResource.union(parsedStatements[0],

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -472,40 +472,42 @@ public class LifecycleTaskService {
       // Use a copy to prevent modifications to the original set
       Set<String> oriFilterValues = filters.get(key);
       Set<String> filterValues = new LinkedHashSet<>(oriFilterValues);
-      // For blank filters with no other values, statements are encapsulated in MINUS
+      // For blank filters with no other values, anchor the event statement OUTSIDE the MINUS
       if (filterValues.contains(QueryResource.NULL_KEY) && filterValues.size() == 1) {
-        queryBuilder.append(QueryResource.minus(eventTargetQueryStatement + statement));
+        queryBuilder.append(eventTargetQueryStatement)
+                    .append(QueryResource.minus(statement));
         hasOptionalClause = false;
         continue;
       }
 
       StringBuilder filterExpression = new StringBuilder();
-      // For other filters where null may be mixed in, first generate a VALUES clause
-      // without any null by removing the value
+      // For mixed (blanks + specific values), generate a UNION arm for each
       if (filterValues.contains(QueryResource.NULL_KEY)) {
-        QueryResource.genDefaultDatatypeFilters(eventTargetQueryStatement + statement, key, filterValues,
-            filterExpression);
-        queryBuilder.append(filterExpression.toString());
+        // Arm 1: The anchored blank-filtering MINUS block
+        String blankArm = eventTargetQueryStatement + QueryResource.minus(statement);
+        
+        // Arm 2: The standard values block matching the specific string
+        StringBuilder mixedFilterExpr = new StringBuilder();
+        QueryResource.genDefaultDatatypeFilters(statement, key, filterValues, mixedFilterExpr);
+        String valueArm = eventTargetQueryStatement + statement + mixedFilterExpr.toString();
+        
+        // Combine them into a local UNION arm
+        queryBuilder.append(QueryResource.union(blankArm, valueArm));
         hasOptionalClause = false;
         hasMinusClause = false;
         continue;
       }
 
-      // Else simply attach them as they are
-      // Do not add event statement here as there may be duplicates with multiple
-      // active filters
+      // Else simply attach standard value filters matching the specific string
       QueryResource.genDefaultDatatypeFilters(statement, key, filterValues, filterExpression);
-      queryBuilder.append(statement)
-          .append(filterExpression.toString());
-      addEventStatement = true;
+      queryBuilder.append(eventTargetQueryStatement)
+                  .append(statement)
+                  .append(filterExpression.toString());
       hasOptionalClause = false;
       hasMinusClause = false;
     }
 
     String query = queryBuilder.toString();
-    if (addEventStatement) {
-      query = eventTargetQueryStatement + query;
-    }
     // replace all iri variables with the event variable
     query = query.replace(QueryResource.IRI_VAR.getQueryString(), eventVar);
     return new ServiceEventFilterQueryManifest(query, filteredStatementMappings.keySet().contains(filterField),

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -451,16 +451,68 @@ public class LifecycleTaskService {
     if (filteredStatementMappings.isEmpty()) {
       return new ServiceEventFilterQueryManifest("", false, false, false, false);
     }
-    boolean addEventStatement = false;
+    
     boolean hasOptionalClause = true;
     boolean hasMinusClause = true;
     StringBuilder queryBuilder = new StringBuilder();
     String eventVar = QueryResource.genVariable(lifecycleEvent.getId() + "_event").getQueryString();
     String eventTargetQueryStatement = LifecycleResource.genOccurrenceTargetQueryStatement(eventVar, lifecycleEvent);
 
+    // When multiple filters are applicable for the same event, we need to combine them in the same query block
+    if (filteredStatementMappings.size() > 1) {
+      // To safely combine multiple filters (blanks, values, or mixed) without variable scope clashing, 
+      // anchor the event target query at the beginning of the block once.
+      // All inner cases then append raw statements sequentially. This forces a logical AND intersection 
+      // behind a single cohesive parent path, preventing cross-contamination between parallel event fields.
+
+      queryBuilder.append(eventTargetQueryStatement);
+
+      for (Map.Entry<String, String> entry : filteredStatementMappings.entrySet()) {
+        String key = entry.getKey();
+        String statement = entry.getValue();
+        Set<String> filterValues = new LinkedHashSet<>(filters.get(key));
+
+        // For sorted fields or target filter field, the entire statement is optional
+        if (key.equals(StringResource.SORT_KEY) || (key.equals(filterField) && filterValues.isEmpty())) {
+          queryBuilder.append(QueryResource.optional(statement));
+          continue;
+        }
+
+        // Pure Blank Filter
+        // Chaining separate MINUS blocks consecutively creates a strict logical AND exclusion
+        if (filterValues.contains(QueryResource.NULL_KEY) && filterValues.size() == 1) {
+          queryBuilder.append(QueryResource.minus(statement));
+          continue;
+        }
+
+        // Mixed (Blanks + Specific Value Match strings)
+        if (filterValues.contains(QueryResource.NULL_KEY)) {
+          StringBuilder mixedFilterExpr = new StringBuilder();
+          QueryResource.genDefaultDatatypeFilters(statement, key, filterValues, mixedFilterExpr);
+          queryBuilder.append(mixedFilterExpr.toString());
+          continue;
+        }
+
+        // Values Only Match for this property
+        StringBuilder filterExpression = new StringBuilder();
+        QueryResource.genDefaultDatatypeFilters(statement, key, filterValues, filterExpression);
+        queryBuilder.append(statement).append(filterExpression.toString());
+      }
+
+      // replace all iri variables with the event variable
+      String query = queryBuilder.toString().replace(QueryResource.IRI_VAR.getQueryString(), eventVar);
+
+      // Flag Override for Multi-Filter Manifests
+      // Prevent calling function to wrap the combined multi-property block in a global macro-wrapper
+      return new ServiceEventFilterQueryManifest(query, filteredStatementMappings.keySet().contains(filterField),
+          true, false, false);
+    }
+
+    // When only one filter is applicable, we can directly wrap the entire block with the appropriate macro based on the filter type
     for (Map.Entry<String, String> entry : filteredStatementMappings.entrySet()) {
       String key = entry.getKey();
       String statement = entry.getValue();
+
       // For sorted fields or target filter field, the entire statement is optional
       // Note that the event target query statement must be wrapped within the clause
       // to be correct
@@ -469,10 +521,11 @@ public class LifecycleTaskService {
         hasMinusClause = false;
         continue;
       }
+      
       // Use a copy to prevent modifications to the original set
       Set<String> oriFilterValues = filters.get(key);
       Set<String> filterValues = new LinkedHashSet<>(oriFilterValues);
-      // For blank filters with no other values, anchor the event statement OUTSIDE the MINUS
+      // For blank filters with no other values, statements are encapsulated in MINUS
       if (filterValues.contains(QueryResource.NULL_KEY) && filterValues.size() == 1) {
         queryBuilder.append(eventTargetQueryStatement)
                     .append(QueryResource.minus(statement));
@@ -483,15 +536,15 @@ public class LifecycleTaskService {
       StringBuilder filterExpression = new StringBuilder();
       // For mixed (blanks + specific values), generate a UNION arm for each
       if (filterValues.contains(QueryResource.NULL_KEY)) {
-        // Arm 1: The anchored blank-filtering MINUS block
+        // The anchored blank-filtering MINUS block
         String blankArm = eventTargetQueryStatement + QueryResource.minus(statement);
         
-        // Arm 2: The standard values block matching the specific string
+        // The standard values block matching the specific string
         StringBuilder mixedFilterExpr = new StringBuilder();
         QueryResource.genDefaultDatatypeFilters(statement, key, filterValues, mixedFilterExpr);
         String valueArm = eventTargetQueryStatement + statement + mixedFilterExpr.toString();
         
-        // Combine them into a local UNION arm
+        // Combine them into a local UNION
         queryBuilder.append(QueryResource.union(blankArm, valueArm));
         hasOptionalClause = false;
         hasMinusClause = false;
@@ -510,6 +563,7 @@ public class LifecycleTaskService {
     String query = queryBuilder.toString();
     // replace all iri variables with the event variable
     query = query.replace(QueryResource.IRI_VAR.getQueryString(), eventVar);
+    
     return new ServiceEventFilterQueryManifest(query, filteredStatementMappings.keySet().contains(filterField),
         // Active filter is true if there are at least two mappings OR if there is one
         // field but does not contain the filter

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -383,8 +383,7 @@ public class LifecycleTaskService {
         addFilterQueries += unionStatement;
       }
 
-      addFilterQueries += this.genServiceEventsQueryStatements(field, LifecycleEventType.SERVICE_EXEMPT,
-          sortedFields, serviceEventFilters).query();
+      addFilterQueries += this.buildExemptionFilterQuery(field, serviceEventFilters, sortedFields);
     }
 
     Map<String, String> extendedMappings = this.lifecycleQueryFactory
@@ -402,6 +401,61 @@ public class LifecycleTaskService {
     } else {
       return new String[] { lifecycleStatements };
     }
+  }
+
+  private String buildExemptionFilterQuery(
+      String field,
+      Map<String, Set<String>> serviceEventFilters,
+      Set<String> sortedFields) {
+
+    StringBuilder sb = new StringBuilder();
+
+    // Calls the framework method using your exact parameter types and order
+    ServiceEventFilterQueryManifest exemptManifest = this.genServiceEventsQueryStatements(
+        field,
+        LifecycleEventType.SERVICE_EXEMPT,
+        sortedFields,
+        serviceEventFilters);
+
+    if (exemptManifest.query() != null && !exemptManifest.query().trim().isEmpty()) {
+      boolean isLookingUpThisStage = exemptManifest.hasFilterField && !exemptManifest.hasActiveFilters;
+
+      // If a blank-only or mixed filter is active, handle it safely using variable
+      // boundaries
+      if ((exemptManifest.onlyMinusFilter() || exemptManifest.query().contains("UNION")) && !isLookingUpThisStage) {
+
+        // 1. Obtain target variable name dynamically
+        String exemptEventVar = QueryResource.genVariable(LifecycleEventType.SERVICE_EXEMPT.getId() + "_event")
+            .getQueryString();
+
+        // 2. Track whether the manifest block successfully matches its internal
+        // property rules
+        sb.append(" OPTIONAL { ")
+            .append(exemptManifest.query())
+            .append(" BIND('true' AS ?exempt_manifest_matched) ")
+            .append(" } ");
+
+        // 3. Track if the exemption stage exists on the timeline at all, using a plain
+        // lookup to avoid the inner MINUS block
+        sb.append(" OPTIONAL { ")
+            .append(exemptEventVar)
+            .append(
+                " <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> <https://www.theworldavatar.com/kg/ontoservice/ServiceAccrualExemptionEvent> ; ")
+            .append("<https://www.omg.org/spec/Commons/DatesAndTimes/succeeds>* ?order_event . ")
+            .append(" BIND('true' AS ?exemption_stage_exists) ")
+            .append(" } ");
+
+        // 4. Boundary Filter Logic
+        sb.append(" FILTER (!BOUND(?exemption_stage_exists) || BOUND(?exempt_manifest_matched)) ");
+
+      } else {
+        // Case 1 (Dropdown lookups) and Case 2 (Strict value filters) stay flat and
+        // strict
+        sb.append(exemptManifest.query());
+      }
+    }
+
+    return sb.toString();
   }
 
   /**
@@ -451,19 +505,23 @@ public class LifecycleTaskService {
     if (filteredStatementMappings.isEmpty()) {
       return new ServiceEventFilterQueryManifest("", false, false, false, false);
     }
-    
+
     boolean hasOptionalClause = true;
     boolean hasMinusClause = true;
     StringBuilder queryBuilder = new StringBuilder();
     String eventVar = QueryResource.genVariable(lifecycleEvent.getId() + "_event").getQueryString();
     String eventTargetQueryStatement = LifecycleResource.genOccurrenceTargetQueryStatement(eventVar, lifecycleEvent);
 
-    // When multiple filters are applicable for the same event, we need to combine them in the same query block
+    // When multiple filters are applicable for the same event, we need to combine
+    // them in the same query block
     if (filteredStatementMappings.size() > 1) {
-      // To safely combine multiple filters (blanks, values, or mixed) without variable scope clashing, 
+      // To safely combine multiple filters (blanks, values, or mixed) without
+      // variable scope clashing,
       // anchor the event target query at the beginning of the block once.
-      // All inner cases then append raw statements sequentially. This forces a logical AND intersection 
-      // behind a single cohesive parent path, preventing cross-contamination between parallel event fields.
+      // All inner cases then append raw statements sequentially. This forces a
+      // logical AND intersection
+      // behind a single cohesive parent path, preventing cross-contamination between
+      // parallel event fields.
 
       queryBuilder.append(eventTargetQueryStatement);
 
@@ -479,7 +537,8 @@ public class LifecycleTaskService {
         }
 
         // Pure Blank Filter
-        // Chaining separate MINUS blocks consecutively creates a strict logical AND exclusion
+        // Chaining separate MINUS blocks consecutively creates a strict logical AND
+        // exclusion
         if (filterValues.contains(QueryResource.NULL_KEY) && filterValues.size() == 1) {
           queryBuilder.append(QueryResource.minus(statement));
           continue;
@@ -489,14 +548,15 @@ public class LifecycleTaskService {
         if (filterValues.contains(QueryResource.NULL_KEY)) {
           StringBuilder mixedFilterExpr = new StringBuilder();
           QueryResource.genDefaultDatatypeFilters(statement, key, filterValues, mixedFilterExpr);
-          // Inject the event target query statement anchor inside the first arm 
-          // of the nested UNION block to prevent the standalone MINUS clause from running in 
+          // Inject the event target query statement anchor inside the first arm
+          // of the nested UNION block to prevent the standalone MINUS clause from running
+          // in
           // an isolated variable scope, which causes blank option wipeouts.
           String mixedStr = mixedFilterExpr.toString();
           if (mixedStr.contains("{MINUS{")) {
             mixedStr = mixedStr.replace("{MINUS{", "{" + eventTargetQueryStatement + "MINUS{");
           }
-          
+
           queryBuilder.append(mixedStr);
           continue;
         }
@@ -511,12 +571,14 @@ public class LifecycleTaskService {
       String query = queryBuilder.toString().replace(QueryResource.IRI_VAR.getQueryString(), eventVar);
 
       // Flag Override for Multi-Filter Manifests
-      // Prevent calling function to wrap the combined multi-property block in a global macro-wrapper
+      // Prevent calling function to wrap the combined multi-property block in a
+      // global macro-wrapper
       return new ServiceEventFilterQueryManifest(query, filteredStatementMappings.keySet().contains(filterField),
           true, false, false);
     }
 
-    // When only one filter is applicable, we can directly wrap the entire block with the appropriate macro based on the filter type
+    // When only one filter is applicable, we can directly wrap the entire block
+    // with the appropriate macro based on the filter type
     for (Map.Entry<String, String> entry : filteredStatementMappings.entrySet()) {
       String key = entry.getKey();
       String statement = entry.getValue();
@@ -529,14 +591,14 @@ public class LifecycleTaskService {
         hasMinusClause = false;
         continue;
       }
-      
+
       // Use a copy to prevent modifications to the original set
       Set<String> oriFilterValues = filters.get(key);
       Set<String> filterValues = new LinkedHashSet<>(oriFilterValues);
       // For blank filters with no other values, statements are encapsulated in MINUS
       if (filterValues.contains(QueryResource.NULL_KEY) && filterValues.size() == 1) {
         queryBuilder.append(eventTargetQueryStatement)
-                    .append(QueryResource.minus(statement));
+            .append(QueryResource.minus(statement));
         hasOptionalClause = false;
         continue;
       }
@@ -546,12 +608,12 @@ public class LifecycleTaskService {
       if (filterValues.contains(QueryResource.NULL_KEY)) {
         // The anchored blank-filtering MINUS block
         String blankArm = eventTargetQueryStatement + QueryResource.minus(statement);
-        
+
         // The standard values block matching the specific string
         StringBuilder mixedFilterExpr = new StringBuilder();
         QueryResource.genDefaultDatatypeFilters(statement, key, filterValues, mixedFilterExpr);
         String valueArm = eventTargetQueryStatement + statement + mixedFilterExpr.toString();
-        
+
         // Combine them into a local UNION
         queryBuilder.append(QueryResource.union(blankArm, valueArm));
         hasOptionalClause = false;
@@ -562,8 +624,8 @@ public class LifecycleTaskService {
       // Else simply attach standard value filters matching the specific string
       QueryResource.genDefaultDatatypeFilters(statement, key, filterValues, filterExpression);
       queryBuilder.append(eventTargetQueryStatement)
-                  .append(statement)
-                  .append(filterExpression.toString());
+          .append(statement)
+          .append(filterExpression.toString());
       hasOptionalClause = false;
       hasMinusClause = false;
     }
@@ -571,7 +633,7 @@ public class LifecycleTaskService {
     String query = queryBuilder.toString();
     // replace all iri variables with the event variable
     query = query.replace(QueryResource.IRI_VAR.getQueryString(), eventVar);
-    
+
     return new ServiceEventFilterQueryManifest(query, filteredStatementMappings.keySet().contains(filterField),
         // Active filter is true if there are at least two mappings OR if there is one
         // field but does not contain the filter

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -489,7 +489,15 @@ public class LifecycleTaskService {
         if (filterValues.contains(QueryResource.NULL_KEY)) {
           StringBuilder mixedFilterExpr = new StringBuilder();
           QueryResource.genDefaultDatatypeFilters(statement, key, filterValues, mixedFilterExpr);
-          queryBuilder.append(mixedFilterExpr.toString());
+          // Inject the event target query statement anchor inside the first arm 
+          // of the nested UNION block to prevent the standalone MINUS clause from running in 
+          // an isolated variable scope, which causes blank option wipeouts.
+          String mixedStr = mixedFilterExpr.toString();
+          if (mixedStr.contains("{MINUS{")) {
+            mixedStr = mixedStr.replace("{MINUS{", "{" + eventTargetQueryStatement + "MINUS{");
+          }
+          
+          queryBuilder.append(mixedStr);
           continue;
         }
 

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.52.2";
+  private static final String API_VERSION = "1.52.3-filter-multi-event-optional-property-SNAPSHOT";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.52.2
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.52.3-filter-multi-event-optional-property-SNAPSHOT
     build:
       context: ..
       target: test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.52.2
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.52.3-filter-multi-event-optional-property-SNAPSHOT
     build:
       context: ..
       target: agent

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.52.2",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.52.3-filter-multi-event-optional-property-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.52.2",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.52.3-filter-multi-event-optional-property-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",


### PR DESCRIPTION
Modified the backend to:

- correctly filter optional properties of lifecycle events when user asks for blank-only, specific values only, and a mixture of blanks and specific values
- correctly handle multiple filers on properties of different types of lifecycle events