### PR TITLE
Ctlao/refactor event property filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.54.0
+
+- Re-factored lifecycle event property filtering and sorting mechanism
+
 ## 1.53.1
 
 - Fixed broken terminate contracts function

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.54.0-refactor-event-filter-SNAPSHOT</version>
+	<version>1.54.0</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.53.1</version>
+	<version>1.54.0-refactor-event-filter-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -384,7 +384,7 @@ public class LifecycleTaskService {
       lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_EXEMPT);
     }
 
-    Map<String, Map<LifecycleEventType, String>> propertyToEventMappings = this.genPropertyEventMappings(field,
+    Map<String, Map<LifecycleEventType, String>> propertyToEventMappings = this.genPropertyEventMappings(
         sortedFields, serviceEventFilters, lifecycleEventsChecklist);
 
     // Identify operation mode
@@ -580,13 +580,12 @@ public class LifecycleTaskService {
   /**
    * Generates property-centric event mappings based on the provided parameters.
    *
-   * @param field                    The field for which to generate mappings.
    * @param sortedFields             The set of sorted fields.
    * @param serviceEventFilters      The map of service event filters.
    * @param lifecycleEventsChecklist The list of lifecycle events to check.
    * @return A map of property-centric event mappings.
    */
-  private Map<String, Map<LifecycleEventType, String>> genPropertyEventMappings(String field, Set<String> sortedFields,
+  private Map<String, Map<LifecycleEventType, String>> genPropertyEventMappings(Set<String> sortedFields,
       Map<String, Set<String>> serviceEventFilters,
       List<LifecycleEventType> lifecycleEventsChecklist) {
 

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -358,22 +358,23 @@ public class LifecycleTaskService {
   /**
    * Builds the filter queries for task events based on the provided parameters.
    *
-   * @param field               The field for which to build filter queries.
-   * @param sortedFields        The set of fields for sorting.
-   * @param filters             The map of service event filters.
-   * @param eventType           The lifecycle event type.
+   * @param field        The field for which to build filter queries.
+   * @param sortedFields The set of fields for sorting.
+   * @param filters      The map of service event filters.
+   * @param eventType    The lifecycle event type.
    * @return The combined filter queries as a string.
    */
   private String buildTaskEventFilterQueries(String field, Set<String> sortedFields,
       Map<String, Set<String>> filters, LifecycleEventType rootEventType) {
 
-    // Create a modifiable copy of the filters to adjust for the lookup field if necessary
+    // Create a modifiable copy of the filters to adjust for the lookup field if
+    // necessary
     Map<String, Set<String>> serviceEventFilters = new HashMap<>(filters);
     if (!field.isEmpty()) {
       // Override the field value for filter options, as it should ignore them
       serviceEventFilters.put(field, new HashSet<>());
     }
-    
+
     // Gather all required statements for properties
     List<LifecycleEventType> lifecycleEventsChecklist = new ArrayList<>();
     lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_ORDER_DISPATCHED);
@@ -425,18 +426,12 @@ public class LifecycleTaskService {
         // property block
         String uniqueVarStr = currentEventType.getId() + "_event_" + propertyKey;
         String uniqueEventVar = QueryResource.genVariable(uniqueVarStr).getQueryString();
-
-        // Generate the dynamic anchor statement bound to our new unique variable name
-        String dynamicAnchor = LifecycleResource.genOccurrenceTargetQueryStatement(uniqueEventVar, currentEventType);
-
-        // Replace the property path placeholder with the exact same unique variable
-        // name
-        String pathStatement = entry.getValue().replace(QueryResource.IRI_VAR.getQueryString(), uniqueEventVar).trim();
-        String finalizedPath = pathStatement.endsWith(".") ? pathStatement : pathStatement + " .";
-        String fullEventPropertyPath = "{ " + dynamicAnchor + " " + finalizedPath + " }";
-
-        unifiedEventBlocks.add(fullEventPropertyPath);
         eventVarsInvolved.add(uniqueEventVar);
+
+        String innerPathContent = prepareEventPropertyPath(entry.getValue(), currentEventType, uniqueEventVar);
+        String fullEventPropertyPath = "{ " + innerPathContent + " }";
+        unifiedEventBlocks.add(fullEventPropertyPath);
+
       }
 
       if (unifiedEventBlocks.isEmpty()) {
@@ -456,7 +451,7 @@ public class LifecycleTaskService {
       // Handle value injection for date type
       if (filterValues.contains(LifecycleResource.DATE_KEY)) {
         filterClauseBuilder.append("{ ").append(combinedGraphPath).append(" }\n");
-        
+
         String dateFiltersStr = QueryResource.genDateFilterExpression(propertyKey, filterValues);
         filterClauseBuilder.append(dateFiltersStr).append("\n");
       } else if (filterValues.contains(QueryResource.NUMERIC_TYPE)) {
@@ -492,7 +487,8 @@ public class LifecycleTaskService {
               .toList();
           String eventsNotBoundCombined = String.join(" && ", eventNotBoundConditions);
 
-          String mixedExpr = "(" + eventsNotBoundCombined + ") || " + propertyValueVar + " IN (" + valuesListString + ")";
+          String mixedExpr = "(" + eventsNotBoundCombined + ") || " + propertyValueVar + " IN (" + valuesListString
+              + ")";
           filterClauseBuilder.append(QueryResource.filter(mixedExpr)).append("\n");
         }
         // Strict selection with explicit values only
@@ -513,24 +509,11 @@ public class LifecycleTaskService {
 
         for (Map.Entry<LifecycleEventType, String> entry : matchedEvents.entrySet()) {
           LifecycleEventType currentEventType = entry.getKey();
-          String sortPathStatement = entry.getValue();
-
-          // Isolate sorting scope using a distinct "_sort" variable suffix
           String sortVarStr = currentEventType.getId() + "_event_sort";
           String uniqueSortEventVar = QueryResource.genVariable(sortVarStr).getQueryString();
 
-          // Build the anchor statement and swap placeholders
-          String dynamicAnchor = LifecycleResource.genOccurrenceTargetQueryStatement(uniqueSortEventVar,
-              currentEventType);
-          sortPathStatement = sortPathStatement.replace(QueryResource.IRI_VAR.getQueryString(), uniqueSortEventVar);
-
-          String trimmedPath = sortPathStatement.trim();
-          String finalizedPath = trimmedPath.endsWith(".") ? trimmedPath : trimmedPath + " .";
-
-          // Combine the dynamic anchor and finalized path into a single inner statement
-          String innerOptionalContent = dynamicAnchor + " " + finalizedPath;
-
-          // Pass it to the helper function and append it to the accumulator
+          String innerOptionalContent = this.prepareEventPropertyPath(entry.getValue(), currentEventType,
+              uniqueSortEventVar);
           finalQueryAccumulator.append(QueryResource.optional(innerOptionalContent)).append("\n");
         }
       }
@@ -544,29 +527,16 @@ public class LifecycleTaskService {
 
         for (Map.Entry<LifecycleEventType, String> entry : matchedEvents.entrySet()) {
           LifecycleEventType currentEventType = entry.getKey();
-          String pathStatement = entry.getValue();
-
           String lookupVarStr = currentEventType.getId() + "_event_lookup";
           String lookupEventVar = QueryResource.genVariable(lookupVarStr).getQueryString();
 
-          String lookupAnchor = LifecycleResource.genOccurrenceTargetQueryStatement(lookupEventVar, currentEventType);
-          pathStatement = pathStatement.replace(QueryResource.IRI_VAR.getQueryString(), lookupEventVar);
-
-          String trimmedPath = pathStatement.trim();
-          String finalizedPath = trimmedPath.endsWith(".") ? trimmedPath : trimmedPath + " .";
-          String fullEventPropertyPath = "{ " + lookupAnchor + " " + finalizedPath + " }";
-          unifiedEventBlocks.add(fullEventPropertyPath);
+          String innerPathContent = this.prepareEventPropertyPath(entry.getValue(), currentEventType, lookupEventVar);
+          unifiedEventBlocks.add("{ " + innerPathContent + " }");
         }
 
         if (!unifiedEventBlocks.isEmpty()) {
-          String combinedGraphPath;
-          if (unifiedEventBlocks.size() == 1) {
-            combinedGraphPath = unifiedEventBlocks.get(0);
-          } else {
-            String[] blocksArray = unifiedEventBlocks.toArray(String[]::new);
-            combinedGraphPath = QueryResource.union(blocksArray[0],
-                Arrays.copyOfRange(blocksArray, 1, blocksArray.length));
-          }
+          String combinedGraphPath = QueryResource.union(unifiedEventBlocks.get(0),
+              unifiedEventBlocks.stream().skip(1).toArray(String[]::new));
 
           finalQueryAccumulator.append(QueryResource.optional(combinedGraphPath)).append("\n");
         }
@@ -574,6 +544,25 @@ public class LifecycleTaskService {
     }
 
     return "\n" + finalQueryAccumulator.toString();
+  }
+
+  /*
+   * Prepares the property path for a given event type and variable.
+   *
+   * @param pathStatement The SPARQL path statement.
+   * @param eventType     The lifecycle event type.
+   * @param uniqueEventVar The unique variable for the event.
+   * @return The prepared event property path.
+   */
+  private String prepareEventPropertyPath(String pathStatement, LifecycleEventType eventType, String uniqueEventVar) {
+    // Generate the dynamic anchor statement bound to the explicit variable
+    String anchor = LifecycleResource.genOccurrenceTargetQueryStatement(uniqueEventVar, eventType);
+
+    // Swap the placeholder and clean up trailing punctuation
+    String replacedPath = pathStatement.replace(QueryResource.IRI_VAR.getQueryString(), uniqueEventVar).trim();
+    String finalizedPath = replacedPath.endsWith(".") ? replacedPath : replacedPath + " .";
+
+    return anchor + " " + finalizedPath;
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -454,8 +454,14 @@ public class LifecycleTaskService {
 
       StringBuilder filterClauseBuilder = new StringBuilder();
 
-      // Handle value injection
-      if (filterValues.contains(QueryResource.NUMERIC_TYPE)) {
+      // Handle value injection for date type
+      if (filterValues.contains(LifecycleResource.DATE_KEY)) {
+        filterClauseBuilder.append("{ ").append(combinedGraphPath).append(" }\n");
+        
+        String dateFiltersStr = QueryResource.genDateFilterExpression(propertyKey, filterValues);
+        filterClauseBuilder.append(dateFiltersStr).append("\n");
+      } else if (filterValues.contains(QueryResource.NUMERIC_TYPE)) {
+        // Handle value injection for numerical type
         filterClauseBuilder.append("{ ").append(combinedGraphPath).append(" }\n");
 
         String numericalFilterExpression = QueryResource.genNumericalFilterExpression(propertyKey, filterValues);

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -33,7 +33,6 @@ import com.cmclinnovations.agent.model.util.LifecycleTask;
 import com.cmclinnovations.agent.service.AddService;
 import com.cmclinnovations.agent.service.GetService;
 import com.cmclinnovations.agent.service.UpdateService;
-import com.cmclinnovations.agent.service.application.LifecycleTaskService.ServiceEventFilterQueryManifest;
 import com.cmclinnovations.agent.service.core.DateTimeService;
 import com.cmclinnovations.agent.service.core.FileService;
 import com.cmclinnovations.agent.template.LifecycleQueryFactory;
@@ -64,10 +63,6 @@ public class LifecycleTaskService {
   static final Logger LOGGER = LogManager.getLogger(LifecycleTaskService.class);
 
   private static final boolean IS_CONTRACT = false;
-
-  final record ServiceEventFilterQueryManifest(String query, boolean hasFilterField, boolean hasActiveFilters,
-      boolean onlyOptionalField, boolean onlyMinusFilter) {
-  }
 
   /**
    * Constructs a new service with the following dependencies.
@@ -647,90 +642,6 @@ public class LifecycleTaskService {
         .map(binding -> this.lifecycleQueryService.parseLifecycleBinding(binding.get()))
         .toList(),
         resultsManifest.columns());
-  }
-
-  /**
-   * Generates the query statements for service events such as dispatch, complete,
-   * cancel, and report if required.
-   * 
-   * @param filterField    Optional filter specific field name.
-   * @param lifecycleEvent Target event type.
-   * @param sortedFields   Set of fields for sorting that should be included.
-   * @param filters        Filters with name and values.
-   */
-  private ServiceEventFilterQueryManifest genServiceEventsQueryStatements(String filterField,
-      LifecycleEventType lifecycleEvent,
-      Set<String> sortedFields, Map<String, Set<String>> filters) {
-    Map<String, String> filteredStatementMappings = this.getService.getStatementMappingsForTargetFields(
-        lifecycleEvent.getShaclReplacement(), sortedFields, filters);
-    if (filteredStatementMappings.isEmpty()) {
-      return new ServiceEventFilterQueryManifest("", false, false, false, false);
-    }
-    boolean addEventStatement = false;
-    boolean hasOptionalClause = true;
-    boolean hasMinusClause = true;
-    StringBuilder queryBuilder = new StringBuilder();
-    String eventVar = QueryResource.genVariable(lifecycleEvent.getId() + "_event").getQueryString();
-    String eventTargetQueryStatement = LifecycleResource.genOccurrenceTargetQueryStatement(eventVar, lifecycleEvent);
-
-    for (Map.Entry<String, String> entry : filteredStatementMappings.entrySet()) {
-      String key = entry.getKey();
-      String statement = entry.getValue();
-      // For sorted fields or target filter field, the entire statement is optional
-      // Note that the event target query statement must be wrapped within the clause
-      // to be correct
-      if (key.equals(StringResource.SORT_KEY) || (key.equals(filterField) && filters.get(key).isEmpty())) {
-        queryBuilder.append(QueryResource.optional(eventTargetQueryStatement + statement));
-        hasMinusClause = false;
-        continue;
-      }
-      // Use a copy to prevent modifications to the original set
-      Set<String> oriFilterValues = filters.get(key);
-      Set<String> filterValues = new LinkedHashSet<>(oriFilterValues);
-      // For blank filters with no other values, statements are encapsulated in MINUS
-      if (filterValues.contains(QueryResource.NULL_KEY) && filterValues.size() == 1) {
-        queryBuilder.append(QueryResource.minus(eventTargetQueryStatement + statement));
-        hasOptionalClause = false;
-        continue;
-      }
-
-      StringBuilder filterExpression = new StringBuilder();
-      // For other filters where null may be mixed in, first generate a VALUES clause
-      // without any null by removing the value
-      if (filterValues.contains(QueryResource.NULL_KEY)) {
-        QueryResource.genDefaultDatatypeFilters(eventTargetQueryStatement + statement, key, filterValues,
-            filterExpression);
-        queryBuilder.append(filterExpression.toString());
-        hasOptionalClause = false;
-        hasMinusClause = false;
-        continue;
-      }
-
-      // Else simply attach them as they are
-      // Do not add event statement here as there may be duplicates with multiple
-      // active filters
-      QueryResource.genDefaultDatatypeFilters(statement, key, filterValues, filterExpression);
-      queryBuilder.append(statement)
-          .append(filterExpression.toString());
-      addEventStatement = true;
-      hasOptionalClause = false;
-      hasMinusClause = false;
-    }
-
-    String query = queryBuilder.toString();
-    if (addEventStatement) {
-      query = eventTargetQueryStatement + query;
-    }
-    // replace all iri variables with the event variable
-    query = query.replace(QueryResource.IRI_VAR.getQueryString(), eventVar);
-    return new ServiceEventFilterQueryManifest(query, filteredStatementMappings.keySet().contains(filterField),
-        // Active filter is true if there are at least two mappings OR if there is one
-        // field but does not contain the filter
-        filteredStatementMappings.size() > 1 || !filteredStatementMappings.keySet().contains(filterField),
-        // Check if all clauses is wrapped in optional clause
-        filteredStatementMappings.size() > 0 && hasOptionalClause,
-        // Check if all clauses is wrapped in minus clause
-        filteredStatementMappings.size() > 0 && hasMinusClause);
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -334,14 +334,9 @@ public class LifecycleTaskService {
         eventType.equals(LifecycleEventType.ACTIVE_SERVICE));
     Map<String, String> statementMappings = this.lifecycleQueryFactory.getServiceTasksQuery(null,
         targetStartEndDates[0], targetStartEndDates[1], eventType);
-    Map<String, Set<String>> serviceEventFilters = new HashMap<>(filters);
-    if (!field.isEmpty()) {
-      // Override the field value for filter options, as it should ignore them
-      serviceEventFilters.put(field, new HashSet<>());
-    }
     // Get combined filter statements for events that matches any sort/filter
     // criteria
-    String addFilterQueries = this.buildTaskEventFilterQueries(field, sortedFields, serviceEventFilters, eventType);
+    String addFilterQueries = this.buildTaskEventFilterQueries(field, sortedFields, filters, eventType);
 
     Map<String, String> extendedMappings = this.lifecycleQueryFactory
         .insertExtendedLastModifiedFilters(statementMappings);
@@ -365,13 +360,20 @@ public class LifecycleTaskService {
    *
    * @param field               The field for which to build filter queries.
    * @param sortedFields        The set of fields for sorting.
-   * @param serviceEventFilters The map of service event filters.
+   * @param filters             The map of service event filters.
    * @param eventType           The lifecycle event type.
    * @return The combined filter queries as a string.
    */
   private String buildTaskEventFilterQueries(String field, Set<String> sortedFields,
-      Map<String, Set<String>> serviceEventFilters, LifecycleEventType rootEventType) {
+      Map<String, Set<String>> filters, LifecycleEventType rootEventType) {
 
+    // Create a modifiable copy of the filters to adjust for the lookup field if necessary
+    Map<String, Set<String>> serviceEventFilters = new HashMap<>(filters);
+    if (!field.isEmpty()) {
+      // Override the field value for filter options, as it should ignore them
+      serviceEventFilters.put(field, new HashSet<>());
+    }
+    
     // Gather all required statements for properties
     List<LifecycleEventType> lifecycleEventsChecklist = new ArrayList<>();
     lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_ORDER_DISPATCHED);
@@ -418,7 +420,6 @@ public class LifecycleTaskService {
 
       for (Map.Entry<LifecycleEventType, String> entry : matchedEvents.entrySet()) {
         LifecycleEventType currentEventType = entry.getKey();
-        String pathStatement = entry.getValue();
 
         // Dynamically build a completely unique variable name for this specific
         // property block
@@ -430,10 +431,8 @@ public class LifecycleTaskService {
 
         // Replace the property path placeholder with the exact same unique variable
         // name
-        pathStatement = pathStatement.replace(QueryResource.IRI_VAR.getQueryString(), uniqueEventVar);
-
-        String trimmedPath = pathStatement.trim();
-        String finalizedPath = trimmedPath.endsWith(".") ? trimmedPath : trimmedPath + " .";
+        String pathStatement = entry.getValue().replace(QueryResource.IRI_VAR.getQueryString(), uniqueEventVar).trim();
+        String finalizedPath = pathStatement.endsWith(".") ? pathStatement : pathStatement + " .";
         String fullEventPropertyPath = "{ " + dynamicAnchor + " " + finalizedPath + " }";
 
         unifiedEventBlocks.add(fullEventPropertyPath);

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -410,7 +410,7 @@ public class LifecycleTaskService {
         continue;
       }
 
-      String propertyValueVar = "?" + propertyKey;
+      String propertyValueVar = QueryResource.genVariable(propertyKey).getQueryString();
       List<String> unifiedEventBlocks = new ArrayList<>();
       List<String> eventVarsInvolved = new ArrayList<>();
 

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -344,9 +344,43 @@ public class LifecycleTaskService {
       // Override the field value for filter options, as it should ignore them
       serviceEventFilters.put(field, new HashSet<>());
     }
+    // Get combined filter statements for events that matches any sort/filter criteria
+    String addFilterQueries = this.buildTaskEventFilterQueries(field, sortedFields, serviceEventFilters, eventType);
+
+    Map<String, String> extendedMappings = this.lifecycleQueryFactory
+        .insertExtendedLastModifiedFilters(statementMappings);
+    // The add filters are only required for getting IDs and not the main query
+    extendedMappings.put(LifecycleResource.LIFECYCLE_RESOURCE,
+        statementMappings.get(LifecycleResource.LIFECYCLE_RESOURCE) + addFilterQueries);
+    // Include an empty date statement to support filtering
+    extendedMappings.put(LifecycleResource.DATE_KEY, "");
+    String lifecycleStatements = this.lifecycleQueryService.genLifecycleStatements(extendedMappings, sortedFields,
+        filters, field);
+    if (reqOriStatements) {
+      return new String[] { lifecycleStatements,
+          statementMappings.values().stream().collect(Collectors.joining("\n")) };
+    } else {
+      return new String[] { lifecycleStatements };
+    }
+  }
+
+  /**
+   * Builds the filter queries for task events based on the provided parameters.
+   *
+   * @param field              The field for which to build filter queries.
+   * @param sortedFields       The set of fields for sorting.
+   * @param serviceEventFilters The map of service event filters.
+   * @param eventType          The lifecycle event type.
+   * @return The combined filter queries as a string.
+   */
+  private String buildTaskEventFilterQueries(String field, Set<String> sortedFields,
+    Map<String, Set<String>> serviceEventFilters, LifecycleEventType eventType) {
+    
     // Get statements for dispatch events that matches any sort/filter criteria
-    String addFilterQueries = this.genServiceEventsQueryStatements(field, LifecycleEventType.SERVICE_ORDER_DISPATCHED,
-        sortedFields, serviceEventFilters).query();
+    
+    String addFilterQueries = this.genServiceEventsQueryStatements(field,
+        LifecycleEventType.SERVICE_ORDER_DISPATCHED, sortedFields, serviceEventFilters).query();
+
     // Non-closed tasks should not have the closed related statements
     if (eventType.equals(LifecycleEventType.ACTIVE_SERVICE) || eventType.equals(LifecycleEventType.SERVICE_ACCRUAL)) {
       ServiceEventFilterQueryManifest completeQueryStatements = this.genServiceEventsQueryStatements(field,
@@ -355,6 +389,7 @@ public class LifecycleTaskService {
           LifecycleEventType.SERVICE_CANCELLATION, sortedFields, serviceEventFilters);
       ServiceEventFilterQueryManifest reportQueryStatements = this.genServiceEventsQueryStatements(field,
           LifecycleEventType.SERVICE_INCIDENT_REPORT, sortedFields, serviceEventFilters);
+
       List<ServiceEventFilterQueryManifest> queryManifests = List
           .of(completeQueryStatements, cancelQueryStatements, reportQueryStatements);
 
@@ -374,6 +409,7 @@ public class LifecycleTaskService {
             return manifest.query();
           })
           .toList();
+
       // When only one query meets the criteria, add them directly
       if (nonEmptyQueryStatements.size() == 1) {
         addFilterQueries += nonEmptyQueryStatements.get(0);
@@ -394,21 +430,7 @@ public class LifecycleTaskService {
           sortedFields, serviceEventFilters).query();
     }
 
-    Map<String, String> extendedMappings = this.lifecycleQueryFactory
-        .insertExtendedLastModifiedFilters(statementMappings);
-    // The add filters are only required for getting IDs and not the main query
-    extendedMappings.put(LifecycleResource.LIFECYCLE_RESOURCE,
-        statementMappings.get(LifecycleResource.LIFECYCLE_RESOURCE) + addFilterQueries);
-    // Include an empty date statement to support filtering
-    extendedMappings.put(LifecycleResource.DATE_KEY, "");
-    String lifecycleStatements = this.lifecycleQueryService.genLifecycleStatements(extendedMappings, sortedFields,
-        filters, field);
-    if (reqOriStatements) {
-      return new String[] { lifecycleStatements,
-          statementMappings.values().stream().collect(Collectors.joining("\n")) };
-    } else {
-      return new String[] { lifecycleStatements };
-    }
+    return "\n" + addFilterQueries;
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -374,78 +374,204 @@ public class LifecycleTaskService {
    * @return The combined filter queries as a string.
    */
   private String buildTaskEventFilterQueries(String field, Set<String> sortedFields,
-    Map<String, Set<String>> serviceEventFilters, LifecycleEventType eventType) {
-    
+    Map<String, Set<String>> serviceEventFilters, LifecycleEventType rootEventType) {
+
+    // Gather all required statements for properties
     List<LifecycleEventType> lifecycleEventsChecklist = new ArrayList<>();
     lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_ORDER_DISPATCHED);
 
-    if (eventType.equals(LifecycleEventType.ACTIVE_SERVICE) || eventType.equals(LifecycleEventType.SERVICE_ACCRUAL)) {
+    if (rootEventType.equals(LifecycleEventType.ACTIVE_SERVICE) || rootEventType.equals(LifecycleEventType.SERVICE_ACCRUAL)) {
       lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_EXECUTION);
       lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_CANCELLATION);
       lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_INCIDENT_REPORT);
       lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_EXEMPT);
     }
 
-    // for all properties, check all event types
-
     Map<String, Map<LifecycleEventType, String>> propertyToEventMappings = this.genPropertyEventMappings(field,
         sortedFields, serviceEventFilters, lifecycleEventsChecklist);
     
-    // Get statements for dispatch events that matches any sort/filter criteria
-    
-    String addFilterQueries = this.genServiceEventsQueryStatements(field,
-        LifecycleEventType.SERVICE_ORDER_DISPATCHED, sortedFields, serviceEventFilters).query();
+    // Identify operation mode
+    StringBuilder finalQueryAccumulator = new StringBuilder();
+    boolean isLookupMode = field != null && !field.isEmpty() && serviceEventFilters.containsKey(field)
+        && serviceEventFilters.get(field).isEmpty();
 
-    // Non-closed tasks should not have the closed related statements
-    if (eventType.equals(LifecycleEventType.ACTIVE_SERVICE) || eventType.equals(LifecycleEventType.SERVICE_ACCRUAL)) {
-      ServiceEventFilterQueryManifest completeQueryStatements = this.genServiceEventsQueryStatements(field,
-          LifecycleEventType.SERVICE_EXECUTION, sortedFields, serviceEventFilters);
-      ServiceEventFilterQueryManifest cancelQueryStatements = this.genServiceEventsQueryStatements(field,
-          LifecycleEventType.SERVICE_CANCELLATION, sortedFields, serviceEventFilters);
-      ServiceEventFilterQueryManifest reportQueryStatements = this.genServiceEventsQueryStatements(field,
-          LifecycleEventType.SERVICE_INCIDENT_REPORT, sortedFields, serviceEventFilters);
-
-      List<ServiceEventFilterQueryManifest> queryManifests = List
-          .of(completeQueryStatements, cancelQueryStatements, reportQueryStatements);
-
-      boolean hasAllOptionalFields = queryManifests.stream()
-          .allMatch(manifest -> manifest.onlyOptionalField() && !manifest.hasActiveFilters);
-      boolean hasAllMinusFields = queryManifests.stream()
-          .allMatch(manifest -> manifest.onlyMinusFilter() && !manifest.hasFilterField);
-
-      List<String> nonEmptyQueryStatements = queryManifests.stream()
-          .filter(manifest -> manifest.query() != null && !manifest.query().trim().isEmpty())
-          .map(manifest -> {
-            if (hasAllOptionalFields) {
-              return QueryResource.getClauseContents(manifest.query(), true);
-            } else if (hasAllMinusFields) {
-              return QueryResource.getClauseContents(manifest.query(), false);
-            }
-            return manifest.query();
-          })
-          .toList();
-
-      // When only one query meets the criteria, add them directly
-      if (nonEmptyQueryStatements.size() == 1) {
-        addFilterQueries += nonEmptyQueryStatements.get(0);
-        // When multiple queries meet the filter/sort criteria
-      } else if (!nonEmptyQueryStatements.isEmpty()) {
-        String[] parsedStatements = nonEmptyQueryStatements.toArray(String[]::new);
-        String unionStatement = QueryResource.union(parsedStatements[0],
-            Arrays.copyOfRange(parsedStatements, 1, parsedStatements.length));
-        if (hasAllOptionalFields) {
-          unionStatement = QueryResource.optional(unionStatement);
-        } else if (hasAllMinusFields) {
-          unionStatement = QueryResource.minus(unionStatement);
-        }
-        addFilterQueries += unionStatement;
-      }
-
-      addFilterQueries += this.genServiceEventsQueryStatements(field, LifecycleEventType.SERVICE_EXEMPT,
-          sortedFields, serviceEventFilters).query();
+    // Separate background filters from the active lookup field
+    Set<String> backgroundProperties = new LinkedHashSet<>(serviceEventFilters.keySet());
+    if (isLookupMode) {
+      backgroundProperties.remove(field);
     }
 
-    return "\n" + addFilterQueries;
+    // Explicitly clean out the sort key from background filtering structures
+    backgroundProperties.remove(StringResource.SORT_KEY);
+
+    // Process filtering constraints
+    for (String propertyKey : backgroundProperties) {
+      if (propertyKey.equals(StringResource.SORT_KEY)) {
+        continue;
+      }
+
+      Map<LifecycleEventType, String> matchedEvents = propertyToEventMappings.get(propertyKey);
+      if (matchedEvents == null || matchedEvents.isEmpty()) {
+        continue;
+      }
+
+      String propertyValueVar = "?" + propertyKey;
+      List<String> unifiedEventBlocks = new ArrayList<>();
+      List<String> eventVarsInvolved = new ArrayList<>();
+
+      for (Map.Entry<LifecycleEventType, String> entry : matchedEvents.entrySet()) {
+        LifecycleEventType currentEventType = entry.getKey();
+        String pathStatement = entry.getValue();
+
+        // Dynamically build a completely unique variable name for this specific property block
+        String uniqueVarStr = currentEventType.getId() + "_event_" + propertyKey;
+        String uniqueEventVar = QueryResource.genVariable(uniqueVarStr).getQueryString();
+
+        // Generate the dynamic anchor statement bound to our new unique variable name
+        String dynamicAnchor = LifecycleResource.genOccurrenceTargetQueryStatement(uniqueEventVar, currentEventType);
+
+        // Replace the property path placeholder with the exact same unique variable name
+        pathStatement = pathStatement.replace(QueryResource.IRI_VAR.getQueryString(), uniqueEventVar);
+
+        String trimmedPath = pathStatement.trim();
+        String finalizedPath = trimmedPath.endsWith(".") ? trimmedPath : trimmedPath + " .";
+        String fullEventPropertyPath = "{ " + dynamicAnchor + " " + finalizedPath + " }";
+
+        unifiedEventBlocks.add(fullEventPropertyPath);
+        eventVarsInvolved.add(uniqueEventVar);
+      }
+
+      if (unifiedEventBlocks.isEmpty()) {
+        continue;
+      }
+
+      String combinedGraphPath;
+      if (unifiedEventBlocks.size() == 1) {
+        combinedGraphPath = unifiedEventBlocks.get(0);
+      } else {
+        String[] blocksArray = unifiedEventBlocks.toArray(String[]::new);
+        combinedGraphPath = QueryResource.union(blocksArray[0],
+            Arrays.copyOfRange(blocksArray, 1, blocksArray.length));
+      }
+
+      Set<String> filterValues = serviceEventFilters.get(propertyKey);
+      if (filterValues == null || filterValues.isEmpty()) {
+        continue;
+      }
+
+      StringBuilder filterClauseBuilder = new StringBuilder();
+
+      // Handle value injection
+      if (filterValues.contains(QueryResource.NUMERIC_TYPE)) {
+        filterClauseBuilder.append("{ ").append(combinedGraphPath).append(" }\n");
+
+        String numericalFilterExpression = QueryResource.genNumericalFilterExpression(propertyKey, filterValues);
+        filterClauseBuilder.append(numericalFilterExpression).append("\n");
+      }
+      else {
+        // handle string-base filtering
+        String valuesListString = "";
+        if (filterValues.size() > 1 || (filterValues.size() == 1 && !filterValues.contains(QueryResource.NULL_KEY))) {
+          List<String> explicitValues = filterValues.stream()
+              .filter(val -> !val.equals(QueryResource.NULL_KEY))
+              .toList();
+          valuesListString = String.join(", ", explicitValues);
+        }
+
+        // Blank-Only Selection
+        if (filterValues.contains(QueryResource.NULL_KEY) && filterValues.size() == 1) {
+          filterClauseBuilder.append("OPTIONAL { ").append(combinedGraphPath).append(" }\n");
+          filterClauseBuilder.append("FILTER(!BOUND(").append(propertyValueVar).append("))\n");
+        }
+        // Mixed Selection - Explicit values OR Blanks
+        // NOTE: Keeping this as is since genDefaultDatatypeFilters uses MINUS, which we intentionally bypassed here
+        else if (filterValues.contains(QueryResource.NULL_KEY)) {
+          filterClauseBuilder.append("OPTIONAL { ").append(combinedGraphPath).append(" }\n");
+
+          List<String> eventNotBoundConditions = eventVarsInvolved.stream()
+              .map(eVar -> "!BOUND(" + eVar + ")")
+              .toList();
+          String eventsNotBoundCombined = String.join(" && ", eventNotBoundConditions);
+
+          filterClauseBuilder.append("FILTER((").append(eventsNotBoundCombined).append(") || ")
+              .append(propertyValueVar).append(" IN (").append(valuesListString).append("))\n");
+        }
+        // Strict selection with explicit values only
+        else {
+          filterClauseBuilder.append("{ ").append(combinedGraphPath).append(" }\n");
+          filterClauseBuilder.append("FILTER(").append(propertyValueVar).append(" IN (").append(valuesListString)
+              .append("))\n");
+        }
+      }
+
+      finalQueryAccumulator.append(filterClauseBuilder.toString());
+    }
+
+    // Process sorting constraints after all filtering constraints have been applied
+    if (propertyToEventMappings.containsKey(StringResource.SORT_KEY)) {
+      Map<LifecycleEventType, String> matchedEvents = propertyToEventMappings.get(StringResource.SORT_KEY);
+      if (matchedEvents != null && !matchedEvents.isEmpty()) {
+
+        for (Map.Entry<LifecycleEventType, String> entry : matchedEvents.entrySet()) {
+          LifecycleEventType currentEventType = entry.getKey();
+          String sortPathStatement = entry.getValue();
+
+          // Isolate sorting scope using a distinct "_sort" variable suffix
+          String sortVarStr = currentEventType.getId() + "_event_sort";
+          String uniqueSortEventVar = QueryResource.genVariable(sortVarStr).getQueryString();
+
+          // Build the anchor statement and swap placeholders
+          String dynamicAnchor = LifecycleResource.genOccurrenceTargetQueryStatement(uniqueSortEventVar, currentEventType);
+          sortPathStatement = sortPathStatement.replace(QueryResource.IRI_VAR.getQueryString(), uniqueSortEventVar);
+
+          String trimmedPath = sortPathStatement.trim();
+          String finalizedPath = trimmedPath.endsWith(".") ? trimmedPath : trimmedPath + " .";
+          
+          finalQueryAccumulator.append("OPTIONAL { ")
+                               .append(dynamicAnchor).append(" ")
+                               .append(finalizedPath)
+                               .append(" }\n");
+        }
+      }
+    }
+
+    // Handle active options lookup
+    if (isLookupMode) {
+      Map<LifecycleEventType, String> matchedEvents = propertyToEventMappings.get(field);
+      if (matchedEvents != null && !matchedEvents.isEmpty()) {
+        List<String> unifiedEventBlocks = new ArrayList<>();
+
+        for (Map.Entry<LifecycleEventType, String> entry : matchedEvents.entrySet()) {
+          LifecycleEventType currentEventType = entry.getKey();
+          String pathStatement = entry.getValue();
+
+          String lookupVarStr = currentEventType.getId() + "_event_lookup";
+          String lookupEventVar = QueryResource.genVariable(lookupVarStr).getQueryString();
+
+          String lookupAnchor = LifecycleResource.genOccurrenceTargetQueryStatement(lookupEventVar, currentEventType);
+          pathStatement = pathStatement.replace(QueryResource.IRI_VAR.getQueryString(), lookupEventVar);
+
+          String trimmedPath = pathStatement.trim();
+          String finalizedPath = trimmedPath.endsWith(".") ? trimmedPath : trimmedPath + " .";
+          String fullEventPropertyPath = "{ " + lookupAnchor + " " + finalizedPath + " }";
+          unifiedEventBlocks.add(fullEventPropertyPath);
+        }
+
+        if (!unifiedEventBlocks.isEmpty()) {
+          String combinedGraphPath;
+          if (unifiedEventBlocks.size() == 1) {
+            combinedGraphPath = unifiedEventBlocks.get(0);
+          } else {
+            String[] blocksArray = unifiedEventBlocks.toArray(String[]::new);
+            combinedGraphPath = QueryResource.union(blocksArray[0],
+                Arrays.copyOfRange(blocksArray, 1, blocksArray.length));
+          }
+          finalQueryAccumulator.append("OPTIONAL { ").append(combinedGraphPath).append(" }\n");
+        }
+      }
+    }
+
+    return "\n" + finalQueryAccumulator.toString();
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -376,6 +376,21 @@ public class LifecycleTaskService {
   private String buildTaskEventFilterQueries(String field, Set<String> sortedFields,
     Map<String, Set<String>> serviceEventFilters, LifecycleEventType eventType) {
     
+    List<LifecycleEventType> lifecycleEventsChecklist = new ArrayList<>();
+    lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_ORDER_DISPATCHED);
+
+    if (eventType.equals(LifecycleEventType.ACTIVE_SERVICE) || eventType.equals(LifecycleEventType.SERVICE_ACCRUAL)) {
+      lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_EXECUTION);
+      lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_CANCELLATION);
+      lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_INCIDENT_REPORT);
+      lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_EXEMPT);
+    }
+
+    // for all properties, check all event types
+
+    Map<String, Map<LifecycleEventType, String>> propertyToEventMappings = this.genPropertyEventMappings(field,
+        sortedFields, serviceEventFilters, lifecycleEventsChecklist);
+    
     // Get statements for dispatch events that matches any sort/filter criteria
     
     String addFilterQueries = this.genServiceEventsQueryStatements(field,
@@ -431,6 +446,51 @@ public class LifecycleTaskService {
     }
 
     return "\n" + addFilterQueries;
+  }
+
+  /**
+   * Generates property-centric event mappings based on the provided parameters.
+   *
+   * @param field                The field for which to generate mappings.
+   * @param sortedFields         The set of sorted fields.
+   * @param serviceEventFilters  The map of service event filters.
+   * @param lifecycleEventsChecklist  The list of lifecycle events to check.
+   * @return A map of property-centric event mappings.
+   */
+  private Map<String, Map<LifecycleEventType, String>> genPropertyEventMappings(String field, Set<String> sortedFields,
+      Map<String, Set<String>> serviceEventFilters,
+      List<LifecycleEventType> lifecycleEventsChecklist) {
+
+    // stores all matched statements for all event types
+    Map<LifecycleEventType, Map<String, String>> globalLifecycleMappings = new HashMap<>();
+
+    for (LifecycleEventType lifecycleEvent : lifecycleEventsChecklist) {
+
+      Map<String, String> filteredStatementMappings = this.getService.getStatementMappingsForTargetFields(
+          lifecycleEvent.getShaclReplacement(), sortedFields, serviceEventFilters);
+      globalLifecycleMappings.put(lifecycleEvent, filteredStatementMappings);
+    }
+
+    // Pivot the data structure to be property-centric
+    
+    Map<String, Map<LifecycleEventType, String>> propertyToEventMappings = new HashMap<>();
+    for (Map.Entry<LifecycleEventType, Map<String, String>> eventEntry : globalLifecycleMappings.entrySet()) {
+      LifecycleEventType eventTypeKey = eventEntry.getKey();
+      Map<String, String> propertyMappings = eventEntry.getValue();
+
+      if (propertyMappings != null) {
+        for (Map.Entry<String, String> propEntry : propertyMappings.entrySet()) {
+          String propertyKey = propEntry.getKey();
+          String sparqlStatement = propEntry.getValue();
+
+          // Compute or create the inner map for this specific property
+          propertyToEventMappings.computeIfAbsent(propertyKey, k -> new HashMap<>())
+              .put(eventTypeKey, sparqlStatement);
+        }
+      }
+    }
+
+    return propertyToEventMappings;
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -339,7 +339,8 @@ public class LifecycleTaskService {
       // Override the field value for filter options, as it should ignore them
       serviceEventFilters.put(field, new HashSet<>());
     }
-    // Get combined filter statements for events that matches any sort/filter criteria
+    // Get combined filter statements for events that matches any sort/filter
+    // criteria
     String addFilterQueries = this.buildTaskEventFilterQueries(field, sortedFields, serviceEventFilters, eventType);
 
     Map<String, String> extendedMappings = this.lifecycleQueryFactory
@@ -362,20 +363,21 @@ public class LifecycleTaskService {
   /**
    * Builds the filter queries for task events based on the provided parameters.
    *
-   * @param field              The field for which to build filter queries.
-   * @param sortedFields       The set of fields for sorting.
+   * @param field               The field for which to build filter queries.
+   * @param sortedFields        The set of fields for sorting.
    * @param serviceEventFilters The map of service event filters.
-   * @param eventType          The lifecycle event type.
+   * @param eventType           The lifecycle event type.
    * @return The combined filter queries as a string.
    */
   private String buildTaskEventFilterQueries(String field, Set<String> sortedFields,
-    Map<String, Set<String>> serviceEventFilters, LifecycleEventType rootEventType) {
+      Map<String, Set<String>> serviceEventFilters, LifecycleEventType rootEventType) {
 
     // Gather all required statements for properties
     List<LifecycleEventType> lifecycleEventsChecklist = new ArrayList<>();
     lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_ORDER_DISPATCHED);
 
-    if (rootEventType.equals(LifecycleEventType.ACTIVE_SERVICE) || rootEventType.equals(LifecycleEventType.SERVICE_ACCRUAL)) {
+    if (rootEventType.equals(LifecycleEventType.ACTIVE_SERVICE)
+        || rootEventType.equals(LifecycleEventType.SERVICE_ACCRUAL)) {
       lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_EXECUTION);
       lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_CANCELLATION);
       lifecycleEventsChecklist.add(LifecycleEventType.SERVICE_INCIDENT_REPORT);
@@ -384,7 +386,7 @@ public class LifecycleTaskService {
 
     Map<String, Map<LifecycleEventType, String>> propertyToEventMappings = this.genPropertyEventMappings(field,
         sortedFields, serviceEventFilters, lifecycleEventsChecklist);
-    
+
     // Identify operation mode
     StringBuilder finalQueryAccumulator = new StringBuilder();
     boolean isLookupMode = field != null && !field.isEmpty() && serviceEventFilters.containsKey(field)
@@ -418,14 +420,16 @@ public class LifecycleTaskService {
         LifecycleEventType currentEventType = entry.getKey();
         String pathStatement = entry.getValue();
 
-        // Dynamically build a completely unique variable name for this specific property block
+        // Dynamically build a completely unique variable name for this specific
+        // property block
         String uniqueVarStr = currentEventType.getId() + "_event_" + propertyKey;
         String uniqueEventVar = QueryResource.genVariable(uniqueVarStr).getQueryString();
 
         // Generate the dynamic anchor statement bound to our new unique variable name
         String dynamicAnchor = LifecycleResource.genOccurrenceTargetQueryStatement(uniqueEventVar, currentEventType);
 
-        // Replace the property path placeholder with the exact same unique variable name
+        // Replace the property path placeholder with the exact same unique variable
+        // name
         pathStatement = pathStatement.replace(QueryResource.IRI_VAR.getQueryString(), uniqueEventVar);
 
         String trimmedPath = pathStatement.trim();
@@ -440,14 +444,8 @@ public class LifecycleTaskService {
         continue;
       }
 
-      String combinedGraphPath;
-      if (unifiedEventBlocks.size() == 1) {
-        combinedGraphPath = unifiedEventBlocks.get(0);
-      } else {
-        String[] blocksArray = unifiedEventBlocks.toArray(String[]::new);
-        combinedGraphPath = QueryResource.union(blocksArray[0],
-            Arrays.copyOfRange(blocksArray, 1, blocksArray.length));
-      }
+      String combinedGraphPath = QueryResource.union(unifiedEventBlocks.get(0),
+          unifiedEventBlocks.stream().skip(1).toArray(String[]::new));
 
       Set<String> filterValues = serviceEventFilters.get(propertyKey);
       if (filterValues == null || filterValues.isEmpty()) {
@@ -462,8 +460,7 @@ public class LifecycleTaskService {
 
         String numericalFilterExpression = QueryResource.genNumericalFilterExpression(propertyKey, filterValues);
         filterClauseBuilder.append(numericalFilterExpression).append("\n");
-      }
-      else {
+      } else {
         // handle string-base filtering
         String valuesListString = "";
         if (filterValues.size() > 1 || (filterValues.size() == 1 && !filterValues.contains(QueryResource.NULL_KEY))) {
@@ -475,27 +472,29 @@ public class LifecycleTaskService {
 
         // Blank-Only Selection
         if (filterValues.contains(QueryResource.NULL_KEY) && filterValues.size() == 1) {
-          filterClauseBuilder.append("OPTIONAL { ").append(combinedGraphPath).append(" }\n");
-          filterClauseBuilder.append("FILTER(!BOUND(").append(propertyValueVar).append("))\n");
+          filterClauseBuilder.append(QueryResource.optional(combinedGraphPath)).append("\n");
+          String blankExpr = "!BOUND(" + propertyValueVar + ")";
+          filterClauseBuilder.append(QueryResource.filter(blankExpr)).append("\n");
         }
         // Mixed Selection - Explicit values OR Blanks
-        // NOTE: Keeping this as is since genDefaultDatatypeFilters uses MINUS, which we intentionally bypassed here
+        // NOTE: Keeping this as is since genDefaultDatatypeFilters uses MINUS, which we
+        // intentionally bypassed here
         else if (filterValues.contains(QueryResource.NULL_KEY)) {
-          filterClauseBuilder.append("OPTIONAL { ").append(combinedGraphPath).append(" }\n");
+          filterClauseBuilder.append(QueryResource.optional(combinedGraphPath)).append("\n");
 
           List<String> eventNotBoundConditions = eventVarsInvolved.stream()
               .map(eVar -> "!BOUND(" + eVar + ")")
               .toList();
           String eventsNotBoundCombined = String.join(" && ", eventNotBoundConditions);
 
-          filterClauseBuilder.append("FILTER((").append(eventsNotBoundCombined).append(") || ")
-              .append(propertyValueVar).append(" IN (").append(valuesListString).append("))\n");
+          String mixedExpr = "(" + eventsNotBoundCombined + ") || " + propertyValueVar + " IN (" + valuesListString + ")";
+          filterClauseBuilder.append(QueryResource.filter(mixedExpr)).append("\n");
         }
         // Strict selection with explicit values only
         else {
           filterClauseBuilder.append("{ ").append(combinedGraphPath).append(" }\n");
-          filterClauseBuilder.append("FILTER(").append(propertyValueVar).append(" IN (").append(valuesListString)
-              .append("))\n");
+          String strictExpr = propertyValueVar + " IN (" + valuesListString + ")";
+          filterClauseBuilder.append(QueryResource.filter(strictExpr)).append("\n");
         }
       }
 
@@ -516,16 +515,18 @@ public class LifecycleTaskService {
           String uniqueSortEventVar = QueryResource.genVariable(sortVarStr).getQueryString();
 
           // Build the anchor statement and swap placeholders
-          String dynamicAnchor = LifecycleResource.genOccurrenceTargetQueryStatement(uniqueSortEventVar, currentEventType);
+          String dynamicAnchor = LifecycleResource.genOccurrenceTargetQueryStatement(uniqueSortEventVar,
+              currentEventType);
           sortPathStatement = sortPathStatement.replace(QueryResource.IRI_VAR.getQueryString(), uniqueSortEventVar);
 
           String trimmedPath = sortPathStatement.trim();
           String finalizedPath = trimmedPath.endsWith(".") ? trimmedPath : trimmedPath + " .";
-          
-          finalQueryAccumulator.append("OPTIONAL { ")
-                               .append(dynamicAnchor).append(" ")
-                               .append(finalizedPath)
-                               .append(" }\n");
+
+          // Combine the dynamic anchor and finalized path into a single inner statement
+          String innerOptionalContent = dynamicAnchor + " " + finalizedPath;
+
+          // Pass it to the helper function and append it to the accumulator
+          finalQueryAccumulator.append(QueryResource.optional(innerOptionalContent)).append("\n");
         }
       }
     }
@@ -561,7 +562,8 @@ public class LifecycleTaskService {
             combinedGraphPath = QueryResource.union(blocksArray[0],
                 Arrays.copyOfRange(blocksArray, 1, blocksArray.length));
           }
-          finalQueryAccumulator.append("OPTIONAL { ").append(combinedGraphPath).append(" }\n");
+
+          finalQueryAccumulator.append(QueryResource.optional(combinedGraphPath)).append("\n");
         }
       }
     }
@@ -572,10 +574,10 @@ public class LifecycleTaskService {
   /**
    * Generates property-centric event mappings based on the provided parameters.
    *
-   * @param field                The field for which to generate mappings.
-   * @param sortedFields         The set of sorted fields.
-   * @param serviceEventFilters  The map of service event filters.
-   * @param lifecycleEventsChecklist  The list of lifecycle events to check.
+   * @param field                    The field for which to generate mappings.
+   * @param sortedFields             The set of sorted fields.
+   * @param serviceEventFilters      The map of service event filters.
+   * @param lifecycleEventsChecklist The list of lifecycle events to check.
    * @return A map of property-centric event mappings.
    */
   private Map<String, Map<LifecycleEventType, String>> genPropertyEventMappings(String field, Set<String> sortedFields,
@@ -593,7 +595,7 @@ public class LifecycleTaskService {
     }
 
     // Pivot the data structure to be property-centric
-    
+
     Map<String, Map<LifecycleEventType, String>> propertyToEventMappings = new HashMap<>();
     for (Map.Entry<LifecycleEventType, Map<String, String>> eventEntry : globalLifecycleMappings.entrySet()) {
       LifecycleEventType eventTypeKey = eventEntry.getKey();

--- a/agent/src/main/java/com/cmclinnovations/agent/utils/QueryResource.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/utils/QueryResource.java
@@ -390,22 +390,10 @@ public class QueryResource {
     public static void genDefaultDatatypeFilters(String query, String field, Set<String> filters,
             StringBuilder builder) {
         if (filters.contains(LifecycleResource.DATE_KEY)) {
-            List<String> dateFilters = new ArrayList<>(filters);
-            dateFilters.remove(LifecycleResource.DATE_KEY);
-            // If there is only one date, ensure field matches the selected date
-            if (dateFilters.size() == 1) {
-                builder.append(QueryResource.filter(
-                        MessageFormat.format(QueryResource.DATE_FILTER_TEMPLATE, field, "=", dateFilters.get(0))));
-                // If there is two dates, ensure field matches the selected date range
-            } else {
-                builder.append(QueryResource.filter(
-                        MessageFormat.format(QueryResource.DATE_FILTER_TEMPLATE, field, ">=", dateFilters.get(0))
-                                + "&&" +
-                                MessageFormat.format(QueryResource.DATE_FILTER_TEMPLATE, field, "<=",
-                                        dateFilters.get(1))));
-            }
+            String dateFiltersStr = QueryResource.genDateFilterExpression(field, filters);
+            builder.append(dateFiltersStr);
         } else if (filters.contains(QueryResource.NUMERIC_TYPE)) {
-            String numericalFiltersStr = genNumericalFilterExpression(field, filters);
+            String numericalFiltersStr = QueryResource.genNumericalFilterExpression(field, filters);
             builder.append(numericalFiltersStr);
             // When there are null filter values, the user has requested for blank values,
             // and this should be excluded from the query via a MINUS clause
@@ -428,14 +416,35 @@ public class QueryResource {
         }
     }
 
+    public static String genDateFilterExpression(String field, Set<String> filters) {
+        StringBuilder builder = new StringBuilder();
+        
+        List<String> dateFilters = new ArrayList<>(filters);
+        dateFilters.remove(LifecycleResource.DATE_KEY);
+        // If there is only one date, ensure field matches the selected date
+        if (dateFilters.size() == 1) {
+            builder.append(QueryResource.filter(
+                    MessageFormat.format(QueryResource.DATE_FILTER_TEMPLATE, field, "=", dateFilters.get(0))));
+            // If there is two dates, ensure field matches the selected date range
+        } else {
+            builder.append(QueryResource.filter(
+                    MessageFormat.format(QueryResource.DATE_FILTER_TEMPLATE, field, ">=", dateFilters.get(0))
+                            + "&&" +
+                            MessageFormat.format(QueryResource.DATE_FILTER_TEMPLATE, field, "<=",
+                                    dateFilters.get(1))));
+        }
+
+        return builder.toString();
+    }
+
     /**
      * Generate the numerical filter expression for the numerical filters. The
      * filters should be in the format of operator followed by the target value.
      * 
-     * @param propertyKey The property key of interest.
-     * @param filters     The set of filters provided by the user.
+     * @param field   The field of interest.
+     * @param filters The set of filters provided by the user.
      */
-    public static String genNumericalFilterExpression(String propertyKey, Set<String> filters) {
+    public static String genNumericalFilterExpression(String field, Set<String> filters) {
         StringBuilder builder = new StringBuilder();
 
         List<String> numericFilters = new ArrayList<>(filters);
@@ -449,7 +458,7 @@ public class QueryResource {
 
             builder.append(QueryResource.filter(
                     MessageFormat.format(QueryResource.NUMERIC_FILTER_TEMPLATE,
-                            propertyKey,
+                            field,
                             parsedOperator,
                             targetValue)));
         }

--- a/agent/src/main/java/com/cmclinnovations/agent/utils/QueryResource.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/utils/QueryResource.java
@@ -405,14 +405,8 @@ public class QueryResource {
                                         dateFilters.get(1))));
             }
         } else if (filters.contains(QueryResource.NUMERIC_TYPE)) {
-            List<String> numericFilters = new ArrayList<>(filters);
-            numericFilters.remove(QueryResource.NUMERIC_TYPE);
-            for (int i = 0; i < numericFilters.size(); i += 2) {
-                builder.append(QueryResource.filter(
-                        MessageFormat.format(QueryResource.NUMERIC_FILTER_TEMPLATE, field,
-                                QueryResource.getNumericFilterOperator(numericFilters.get(i)),
-                                numericFilters.get(i + 1))));
-            }
+            String numericalFiltersStr = genNumericalFilterExpression(field, filters);
+            builder.append(numericalFiltersStr);
             // When there are null filter values, the user has requested for blank values,
             // and this should be excluded from the query via a MINUS clause
         } else if (filters.contains(QueryResource.NULL_KEY)) {
@@ -432,6 +426,35 @@ public class QueryResource {
             String valuesClause = QueryResource.values(filters, field);
             builder.append(valuesClause);
         }
+    }
+
+    /**
+     * Generate the numerical filter expression for the numerical filters. The
+     * filters should be in the format of operator followed by the target value.
+     * 
+     * @param propertyKey The property key of interest.
+     * @param filters     The set of filters provided by the user.
+     */
+    public static String genNumericalFilterExpression(String propertyKey, Set<String> filters) {
+        StringBuilder builder = new StringBuilder();
+
+        List<String> numericFilters = new ArrayList<>(filters);
+        numericFilters.remove(QueryResource.NUMERIC_TYPE);
+
+        for (int i = 0; i < numericFilters.size(); i += 2) {
+            String operatorCode = numericFilters.get(i);
+            String targetValue = numericFilters.get(i + 1);
+
+            String parsedOperator = QueryResource.getNumericFilterOperator(operatorCode);
+
+            builder.append(QueryResource.filter(
+                    MessageFormat.format(QueryResource.NUMERIC_FILTER_TEMPLATE,
+                            propertyKey,
+                            parsedOperator,
+                            targetValue)));
+        }
+
+        return builder.toString();
     }
 
     /**

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.54.0-refactor-event-filter-SNAPSHOT";
+  private static final String API_VERSION = "1.54.0";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.53.1";
+  private static final String API_VERSION = "1.54.0-refactor-event-filter-SNAPSHOT";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.54.0-refactor-event-filter-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.54.0
     build:
       context: ..
       target: test

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.53.1
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.54.0-refactor-event-filter-SNAPSHOT
     build:
       context: ..
       target: test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.54.0-refactor-event-filter-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.54.0
     build:
       context: ..
       target: agent

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.53.1
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.54.0-refactor-event-filter-SNAPSHOT
     build:
       context: ..
       target: agent

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.54.0-refactor-event-filter-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.54.0",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.53.1",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.54.0-refactor-event-filter-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.54.0-refactor-event-filter-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.54.0",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.53.1",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.54.0-refactor-event-filter-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",


### PR DESCRIPTION
Re-factored event property filter/sort/lookup statement generation to the following:

- first, retrieve all relevant mappings from the active event types, and re-organise that by property
- for each property, build a specific filter block. Different treatment for the following cases:
  * numerical filter (currently do not consider blank)
  * blank-only selection
  * blank or explicit values
  * explicit values only
- after that, process sorting and/or lookup requirements