### PR TITLE
Ctlao/292 time filter sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.57.0
+
+- Fixed filtering of time datatype
+
 ## 1.56.0
 
 - Added optional dependency check before deleting instances

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.57.0-time-filter-sort-SNAPSHOT</version>
+	<version>1.57.0</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.55.0</version>
+	<version>1.57.0-time-filter-sort-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -454,6 +454,12 @@ public class LifecycleTaskService {
 
         String dateFiltersStr = QueryResource.genDateFilterExpression(propertyKey, filterValues);
         filterClauseBuilder.append(dateFiltersStr).append("\n");
+      } else if (filterValues.contains(QueryResource.TIME_TYPE)) {
+        // Handle value injection for time type
+        filterClauseBuilder.append("{ ").append(combinedGraphPath).append(" }\n");
+
+        String timeFilterExpression = QueryResource.genTimeFilterExpression(propertyKey, filterValues);
+        filterClauseBuilder.append(timeFilterExpression).append("\n");
       } else if (filterValues.contains(QueryResource.NUMERIC_TYPE)) {
         // Handle value injection for numerical type
         filterClauseBuilder.append("{ ").append(combinedGraphPath).append(" }\n");

--- a/agent/src/main/java/com/cmclinnovations/agent/utils/QueryResource.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/utils/QueryResource.java
@@ -126,9 +126,11 @@ public class QueryResource {
     public static final String LITERAL_TYPE = "literal";
     public static final String URI_TYPE = "uri";
     public static final String NUMERIC_TYPE = "numeric";
+    public static final String TIME_TYPE = "time";
 
     public static final String DATE_FILTER_TEMPLATE = "xsd:date(?{0}){1}\"{2}\"^^xsd:date";
     public static final String NUMERIC_FILTER_TEMPLATE = "xsd:decimal(?{0}){1}\"{2}\"^^xsd:decimal";
+    public static final String TIME_FILTER_TEMPLATE = "STR(?{0}){1}\"{2}\"";
 
     public static final String HISTORY_ACTIVITY_RESOURCE = "activity";
     public static final String HISTORY_AGENT_RESOURCE = "agent";
@@ -392,6 +394,9 @@ public class QueryResource {
         if (filters.contains(LifecycleResource.DATE_KEY)) {
             String dateFiltersStr = QueryResource.genDateFilterExpression(field, filters);
             builder.append(dateFiltersStr);
+        } else if (filters.contains(QueryResource.TIME_TYPE)) {
+            String timeFiltersStr = QueryResource.genTimeFilterExpression(field, filters);
+            builder.append(timeFiltersStr);
         } else if (filters.contains(QueryResource.NUMERIC_TYPE)) {
             String numericalFiltersStr = QueryResource.genNumericalFilterExpression(field, filters);
             builder.append(numericalFiltersStr);
@@ -489,6 +494,28 @@ public class QueryResource {
             default:
                 throw new IllegalArgumentException("Invalid operator: " + operator);
         }
+    }
+
+    public static String genTimeFilterExpression(String field, Set<String> filters) {
+        StringBuilder builder = new StringBuilder();
+
+        List<String> numericFilters = new ArrayList<>(filters);
+        numericFilters.remove(QueryResource.TIME_TYPE);
+
+        for (int i = 0; i < numericFilters.size(); i += 2) {
+            String operatorCode = numericFilters.get(i);
+            String targetValue = numericFilters.get(i + 1);
+
+            String parsedOperator = QueryResource.getNumericFilterOperator(operatorCode);
+
+            builder.append(QueryResource.filter(
+                    MessageFormat.format(QueryResource.TIME_FILTER_TEMPLATE,
+                            field,
+                            parsedOperator,
+                            targetValue)));
+        }
+
+        return builder.toString();
     }
 
     /**

--- a/agent/src/main/java/com/cmclinnovations/agent/utils/StringResource.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/utils/StringResource.java
@@ -33,6 +33,8 @@ public class StringResource {
       .compile("(\\d{4}-\\d{2}-\\d{2})\\.\\.(\\d{4}-\\d{2}-\\d{2})");
   public static final Pattern NUMERIC_FILTER_PATTERN = Pattern
       .compile("(eq|neq|gt|lt|gte|lte)(\\d+(?:\\.\\d+)?)");
+  public static final Pattern TIME_FILTER_PATTERN = Pattern
+      .compile("(eq|neq|gt|lt|gte|lte)(\\d{2}:\\d{2})");
 
   // Private constructor to prevent instantiation
   private StringResource() {
@@ -183,6 +185,21 @@ public class StringResource {
       }
       // Early termination for date filters
       return valueSet;
+    }
+
+    // Parse filters for time
+    Matcher timeMatcher = TIME_FILTER_PATTERN.matcher(value);
+    if (timeMatcher.find()) {
+        // Replace with your actual constant for time types if named differently
+        valueSet.add(QueryResource.TIME_TYPE); 
+        do {
+            String operator = timeMatcher.group(1);
+            String timeStr = timeMatcher.group(2);
+            valueSet.add(operator);
+            valueSet.add(timeStr);
+        } while (timeMatcher.find());
+
+        return valueSet;
     }
 
     // Parse filters for numbers

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.57.0-time-filter-sort-SNAPSHOT";
+  private static final String API_VERSION = "1.57.0";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.55.0";
+  private static final String API_VERSION = "1.57.0-time-filter-sort-SNAPSHOT";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.57.0-time-filter-sort-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.57.0
     build:
       context: ..
       target: test

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.55.0
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.57.0-time-filter-sort-SNAPSHOT
     build:
       context: ..
       target: test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.57.0-time-filter-sort-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.57.0
     build:
       context: ..
       target: agent

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.55.0
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.57.0-time-filter-sort-SNAPSHOT
     build:
       context: ..
       target: agent

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.0-time-filter-sort-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.0",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.55.0",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.0-time-filter-sort-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.0-time-filter-sort-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.0",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.55.0",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.0-time-filter-sort-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",


### PR DESCRIPTION
Cast xsd:time to string before applying filtering criteria provided by the user. This is done due to lack of built-in function for xsd:time datatype. This should work correctly providing that all data are of the same hh:mm format.