### PR TITLE
Ctlao/294 shacl cache warmup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.57.1
+
+- Store SHACL endpoint in memory instead of cache
+
 ## 1.57.0
 
 - Fixed filtering of time datatype

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.57.1-shacl-cache-warmup-SNAPSHOT</version>
+	<version>1.57.1</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.57.0</version>
+	<version>1.57.1-shacl-cache-warmup-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/src/main/java/com/cmclinnovations/agent/component/repository/KGRepository.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/component/repository/KGRepository.java
@@ -40,14 +40,13 @@ import tools.jackson.databind.node.ObjectNode;
 
 @Component
 public class KGRepository {
-    @Value("${SHACL_NAMESPACE}")
-    String shaclNamespace;
-
     private final RestClient client;
     private final JsonMapper objectMapper;
     private final FileService fileService;
     private final LoggingService loggingService;
     private final QueryTemplateService queryTemplateService;
+    private final String shaclNamespace;
+    private final String shaclEndpoint;
 
     private static final String DEFAULT_NAMESPACE = "kb";
     private static final String RDF_LIST_PATH_PREFIX = "/rdf:rest";
@@ -62,12 +61,15 @@ public class KGRepository {
      * this behaviour.
      */
     public KGRepository(FileService fileService, LoggingService loggingService,
-            QueryTemplateService queryTemplateService) {
+            QueryTemplateService queryTemplateService, @Value("${SHACL_NAMESPACE}") String shaclNamespace) {
         this.client = RestClient.create();
         this.objectMapper = new JsonMapper();
         this.fileService = fileService;
         this.loggingService = loggingService;
         this.queryTemplateService = queryTemplateService;
+        this.shaclNamespace = shaclNamespace;
+        this.shaclEndpoint = BlazegraphClient.getInstance().getRemoteStoreClient(this.shaclNamespace)
+                .getQueryEndpoint();
     }
 
     /**
@@ -94,10 +96,8 @@ public class KGRepository {
     /**
      * Retrieves the SHACL endpoint URL.
      */
-    @Cacheable(value = "shaclendpoint")
     public String getShaclEndpoint() {
-        return BlazegraphClient.getInstance().getRemoteStoreClient(this.shaclNamespace)
-                .getQueryEndpoint();
+        return this.shaclEndpoint;
     }
 
     /**

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.57.0";
+  private static final String API_VERSION = "1.57.1-shacl-cache-warmup-SNAPSHOT";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.57.1-shacl-cache-warmup-SNAPSHOT";
+  private static final String API_VERSION = "1.57.1";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.57.0
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.57.1-shacl-cache-warmup-SNAPSHOT
     build:
       context: ..
       target: test

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.57.1-shacl-cache-warmup-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.57.1
     build:
       context: ..
       target: test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.57.0
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.57.1-shacl-cache-warmup-SNAPSHOT
     build:
       context: ..
       target: agent

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.57.1-shacl-cache-warmup-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.57.1
     build:
       context: ..
       target: agent

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.0",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.1-shacl-cache-warmup-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.1-shacl-cache-warmup-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.1",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.0",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.1-shacl-cache-warmup-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.1-shacl-cache-warmup-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.1",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",


### PR DESCRIPTION
Stop caching the SHACL endpoint in redis. Instead, store it in the KGRepository class and initialised it once at start up.