### PR TITLE
Ctlao/296 task query improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.58.0
+
+- Re-factored task query to run in parallel for faster query performance
+
 ## 1.57.1
 
 - Store SHACL endpoint in memory instead of cache

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.57.1</version>
+	<version>1.58.0-decouple-event-query-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.58.0-decouple-event-query-SNAPSHOT</version>
+	<version>1.58.0</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/src/main/java/com/cmclinnovations/agent/component/ParallelTaskExecutor.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/component/ParallelTaskExecutor.java
@@ -1,6 +1,7 @@
 package com.cmclinnovations.agent.component;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.StructuredTaskScope;
@@ -58,26 +59,34 @@ public class ParallelTaskExecutor {
         }
     }
 
-    public static <T> List<T> execDualParallelQueries(Callable<T> task1, Callable<T> task2) {
+    /**
+     * Executes a variable of query tasks in parallel using Structured Concurrency.
+     * 
+     * @param tasks A variable number of tasks to perform.
+     */
+    public static <T> List<T> execParallelQueries(Callable<T>... tasks) {
         SecurityContext context = SecurityContextHolder.getContext();
 
         try (var scope = StructuredTaskScope.open(
                 Joiner.<T>allSuccessfulOrThrow(),
                 config -> config.withTimeout(Duration.ofMinutes(1)))) {
 
-            // Fork both tasks asynchronously
-            Subtask<T> subtask1 = scope.fork(new DelegatingSecurityContextCallable<>(task1, context));
-            Subtask<T> subtask2 = scope.fork(new DelegatingSecurityContextCallable<>(task2, context));
+            // Fork all tasks asynchronously
+            List<Subtask<T>> subtasks = Arrays.stream(tasks)
+                    .map(task -> scope.fork(new DelegatingSecurityContextCallable<>(task, context)))
+                    .toList();
 
             try {
-                scope.join(); // Block until both complete or timeout
+                scope.join(); // Block until all complete, one fails, or timeout occurs
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new ParallelInterruptedException("One of the parallel tasks has been interrupted: ", e);
             }
 
-            // Return the results in the exact requested order
-            return List.of(subtask1.get(), subtask2.get());
+            // Gather and return results in the original order of the input tasks
+            return subtasks.stream()
+                    .map(Subtask::get)
+                    .toList();
         }
     }
 }

--- a/agent/src/main/java/com/cmclinnovations/agent/component/ParallelTaskExecutor.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/component/ParallelTaskExecutor.java
@@ -1,6 +1,7 @@
 package com.cmclinnovations.agent.component;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.StructuredTaskScope;
 import java.util.concurrent.StructuredTaskScope.Joiner;
@@ -54,6 +55,29 @@ public class ParallelTaskExecutor {
             }
 
             return new ParallelTableQueryManifest<>(dataSubtask.get(), filteredSubtask.get(), totalSubtask.get());
+        }
+    }
+
+    public static <T> List<T> execDualParallelQueries(Callable<T> task1, Callable<T> task2) {
+        SecurityContext context = SecurityContextHolder.getContext();
+
+        try (var scope = StructuredTaskScope.open(
+                Joiner.<T>allSuccessfulOrThrow(),
+                config -> config.withTimeout(Duration.ofMinutes(1)))) {
+
+            // Fork both tasks asynchronously
+            Subtask<T> subtask1 = scope.fork(new DelegatingSecurityContextCallable<>(task1, context));
+            Subtask<T> subtask2 = scope.fork(new DelegatingSecurityContextCallable<>(task2, context));
+
+            try {
+                scope.join(); // Block until both complete or timeout
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new ParallelInterruptedException("One of the parallel tasks has been interrupted: ", e);
+            }
+
+            // Return the results in the exact requested order
+            return List.of(subtask1.get(), subtask2.get());
         }
     }
 }

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -670,8 +670,9 @@ public class LifecycleTaskService {
     // Query for primary entity
     Set<ColumnMetaPayload> entityVarSequences = new LinkedHashSet<>(this.taskEntityColumnMeta);
     String entityQuery = lifecycleStatements[1];
-    DataManifest<Queue<SparqlBinding>> resultsManifest = this.getService.getInstances(entityType, true, idQueue,
-        entityQuery, new ArrayList<>(entityVarSequences));
+    // DataManifest<Queue<SparqlBinding>> resultsManifest =
+    // this.getService.getInstances(entityType, true, idQueue,
+    // entityQuery, new ArrayList<>(entityVarSequences));
 
     // Query for event
 
@@ -685,7 +686,21 @@ public class LifecycleTaskService {
       addQuery += this.parseEventOccurrenceQuery(LifecycleEventType.SERVICE_EXEMPT, varSequences);
     }
     String occurrenceQueryString = this.genOccurrenceEventQueryStatement(varSequences, eventIdQueue, addQuery);
-    Queue<SparqlBinding> occurrenceResultQueue = this.getService.getInstances(occurrenceQueryString);
+    // Queue<SparqlBinding> occurrenceResultQueue =
+    // this.getService.getInstances(occurrenceQueryString);
+
+    List<DataManifest<Queue<SparqlBinding>>> parallelResults = ParallelTaskExecutor.execDualParallelQueries(
+        // Query for entity
+        () -> this.getService.getInstances(entityType, true, idQueue, entityQuery, new ArrayList<>(entityVarSequences)),
+        // Query for event
+        () -> {
+          Queue<SparqlBinding> queue = this.getService.getInstances(occurrenceQueryString);
+          return new DataManifest<>(queue, new ArrayList<>(varSequences));
+        });
+
+    // Unpack your assignments right below
+    DataManifest<Queue<SparqlBinding>> resultsManifest = parallelResults.get(0);
+    Queue<SparqlBinding> occurrenceResultQueue = parallelResults.get(1).data();
 
     // Combine results from entity query and event query
 
@@ -694,7 +709,7 @@ public class LifecycleTaskService {
     Map<String, Map<String, Object>> eventById = mapBindingsById(occurrenceResultQueue,
         QueryResource.EVENT_ID_VAR.getVarName());
 
-    // Merge data of primary entity and event    
+    // Merge data of primary entity and event
     List<Map<String, Object>> mergedData = new ArrayList<>();
     for (List<String> pair : originalIds) {
       if (pair.size() < 2) {

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -2,7 +2,6 @@ package com.cmclinnovations.agent.service.application;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,6 +58,8 @@ public class LifecycleTaskService {
   private final LifecycleQueryFactory lifecycleQueryFactory;
   private final List<ColumnMetaPayload> taskColumnMeta = new ArrayList<>();
   private final List<ColumnMetaPayload> taskEntityColumnMeta = new ArrayList<>();
+  private final Set<String> excludableLifecycleStatementKeys = Set.of(LifecycleResource.EVENT_KEY,
+      LifecycleResource.LAST_MODIFIED_KEY);
 
   private static final String ORDER_INITIALISE_MESSAGE = "Order received and is being processed.";
   private static final String ORDER_DISPATCH_MESSAGE = "Order has been assigned and is awaiting execution.";
@@ -361,8 +362,7 @@ public class LifecycleTaskService {
 
       // Statements for event properties
       String eventStatements = statementMappings.entrySet().stream()
-          .filter(entry -> Set.of(LifecycleResource.EVENT_KEY, LifecycleResource.LAST_MODIFIED_KEY)
-              .contains(entry.getKey()))
+          .filter(entry -> excludableLifecycleStatementKeys.contains(entry.getKey()))
           .map(Map.Entry::getValue)
           .collect(Collectors.joining("\n"));
 

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -675,12 +675,7 @@ public class LifecycleTaskService {
       eventIds.offer(Collections.singletonList(eventId));
     }
 
-    // Query preparation for primary entity
-    Set<ColumnMetaPayload> entityVarSequences = new LinkedHashSet<>(this.taskEntityColumnMeta);
-    String entityQuery = lifecycleStatements[1];
-
     // Query preparation for event
-
     Set<ColumnMetaPayload> varSequences = new LinkedHashSet<>(this.taskColumnMeta);
     String addQuery = lifecycleStatements[2];
     addQuery += this.parseEventOccurrenceQuery(LifecycleEventType.SERVICE_ORDER_DISPATCHED, varSequences);
@@ -695,8 +690,8 @@ public class LifecycleTaskService {
     // Execute primary entity and event queries in parallel
     List<DataManifest<Queue<SparqlBinding>>> parallelResults = ParallelTaskExecutor.execParallelQueries(
         // Query for entity
-        () -> this.getService.getInstances(entityType, true, uniqueIds, entityQuery,
-            new ArrayList<>(entityVarSequences)),
+        () -> this.getService.getInstances(entityType, true, uniqueIds, lifecycleStatements[1],
+            new ArrayList<>(this.taskEntityColumnMeta)),
         // Query for event
         () -> {
           Queue<SparqlBinding> queue = this.getService.getInstances(occurrenceQueryString);

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -654,22 +653,27 @@ public class LifecycleTaskService {
       return new DataManifest<>(new ArrayList<>(), new ArrayList<>());
     }
 
-    List<List<String>> originalIds = new ArrayList<>(ids); // make it a persistent copy
+    List<List<String>> idEventIdPairs = new ArrayList<>(ids); // make it a persistent copy
 
-    // Initialise separate queues for primary entity and events
-    Set<List<String>> uniqueIdSet = new LinkedHashSet<>();
-    Set<List<String>> uniqueEventIdSet = new LinkedHashSet<>();
-
-    for (List<String> pair : originalIds) {
-      if (pair != null && pair.size() >= 2) {
-        uniqueIdSet.add(Collections.singletonList(pair.get(0)));
-        uniqueEventIdSet.add(Collections.singletonList(pair.get(1)));
+    // Set up for checking
+    Set<String> uniqueIdChecker = new HashSet<>();
+    Queue<List<String>> uniqueIds = new ArrayDeque<>();
+    Queue<List<String>> eventIds = new ArrayDeque<>();
+    while (!ids.isEmpty()) {
+      List<String> idPair = ids.poll();
+      if (idPair == null || idPair.size() < 2) {
+        LOGGER.warn("Skipping incomplete id pairs for: {}...", idPair == null ? "null" : idPair.get(0));
+        continue;
       }
+      // Only add IDs if they are unique by using the set checking
+      String id = idPair.get(0);
+      if (uniqueIdChecker.add(id)) {
+        uniqueIds.offer(Collections.singletonList(id));
+      }
+      // All event Ids are unique
+      String eventId = idPair.get(1);
+      eventIds.offer(Collections.singletonList(eventId));
     }
-
-    // Convert back to queue
-    Queue<List<String>> idQueue = new LinkedList<>(uniqueIdSet);
-    Queue<List<String>> eventIdQueue = new LinkedList<>(uniqueEventIdSet);
 
     // Query preparation for primary entity
     Set<ColumnMetaPayload> entityVarSequences = new LinkedHashSet<>(this.taskEntityColumnMeta);
@@ -686,12 +690,13 @@ public class LifecycleTaskService {
       addQuery += this.parseEventOccurrenceQuery(LifecycleEventType.SERVICE_INCIDENT_REPORT, varSequences);
       addQuery += this.parseEventOccurrenceQuery(LifecycleEventType.SERVICE_EXEMPT, varSequences);
     }
-    String occurrenceQueryString = this.genOccurrenceEventQueryStatement(varSequences, eventIdQueue, addQuery);
+    String occurrenceQueryString = this.genOccurrenceEventQueryStatement(varSequences, eventIds, addQuery);
 
     // Execute primary entity and event queries in parallel
     List<DataManifest<Queue<SparqlBinding>>> parallelResults = ParallelTaskExecutor.execParallelQueries(
         // Query for entity
-        () -> this.getService.getInstances(entityType, true, idQueue, entityQuery, new ArrayList<>(entityVarSequences)),
+        () -> this.getService.getInstances(entityType, true, uniqueIds, entityQuery,
+            new ArrayList<>(entityVarSequences)),
         // Query for event
         () -> {
           Queue<SparqlBinding> queue = this.getService.getInstances(occurrenceQueryString);
@@ -711,7 +716,7 @@ public class LifecycleTaskService {
 
     // Merge data of primary entity and event
     List<Map<String, Object>> mergedData = new ArrayList<>();
-    for (List<String> pair : originalIds) {
+    for (List<String> pair : idEventIdPairs) {
       if (pair.size() < 2) {
         continue;
       }

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -689,7 +689,7 @@ public class LifecycleTaskService {
     String occurrenceQueryString = this.genOccurrenceEventQueryStatement(varSequences, eventIdQueue, addQuery);
 
     // Execute primary entity and event queries in parallel
-    List<DataManifest<Queue<SparqlBinding>>> parallelResults = ParallelTaskExecutor.execDualParallelQueries(
+    List<DataManifest<Queue<SparqlBinding>>> parallelResults = ParallelTaskExecutor.execParallelQueries(
         // Query for entity
         () -> this.getService.getInstances(entityType, true, idQueue, entityQuery, new ArrayList<>(entityVarSequences)),
         // Query for event

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -3,9 +3,13 @@ package com.cmclinnovations.agent.service.application;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -54,6 +58,7 @@ public class LifecycleTaskService {
 
   private final LifecycleQueryFactory lifecycleQueryFactory;
   private final List<ColumnMetaPayload> taskColumnMeta = new ArrayList<>();
+  private final List<ColumnMetaPayload> taskEntityColumnMeta = new ArrayList<>();
 
   private static final String ORDER_INITIALISE_MESSAGE = "Order received and is being processed.";
   private static final String ORDER_DISPATCH_MESSAGE = "Order has been assigned and is awaiting execution.";
@@ -88,7 +93,7 @@ public class LifecycleTaskService {
         .add(new ColumnMetaPayload(LifecycleResource.STATUS_KEY, QueryResource.LITERAL_TYPE, ShaclResource.XSD_STRING));
     this.taskColumnMeta
         .add(QueryResource.EVENT_ID_COL);
-    this.taskColumnMeta.add(new ColumnMetaPayload(LifecycleResource.SCHEDULE_TYPE_KEY, QueryResource.LITERAL_TYPE,
+    this.taskEntityColumnMeta.add(new ColumnMetaPayload(LifecycleResource.SCHEDULE_TYPE_KEY, QueryResource.LITERAL_TYPE,
         ShaclResource.XSD_STRING));
   }
 
@@ -348,8 +353,20 @@ public class LifecycleTaskService {
     String lifecycleStatements = this.lifecycleQueryService.genLifecycleStatements(extendedMappings, sortedFields,
         filters, field);
     if (reqOriStatements) {
-      return new String[] { lifecycleStatements,
-          statementMappings.values().stream().collect(Collectors.joining("\n")) };
+      // Statements for entity properties
+      String entityStatements = statementMappings.entrySet().stream()
+          .filter(entry -> LifecycleResource.SCHEDULE_RECURRENCE_KEY.equals(entry.getKey()))
+          .map(Map.Entry::getValue)
+          .collect(Collectors.joining("\n"));
+
+      // Statements for event properties
+      String eventStatements = statementMappings.entrySet().stream()
+          .filter(entry -> Set.of(LifecycleResource.EVENT_KEY, LifecycleResource.LAST_MODIFIED_KEY)
+              .contains(entry.getKey()))
+          .map(Map.Entry::getValue)
+          .collect(Collectors.joining("\n"));
+
+      return new String[] { lifecycleStatements, entityStatements, eventStatements };
     } else {
       return new String[] { lifecycleStatements };
     }
@@ -556,8 +573,11 @@ public class LifecycleTaskService {
    * Prepares the property path for a given event type and variable.
    *
    * @param pathStatement The SPARQL path statement.
-   * @param eventType     The lifecycle event type.
+   * 
+   * @param eventType The lifecycle event type.
+   * 
    * @param uniqueEventVar The unique variable for the event.
+   * 
    * @return The prepared event property path.
    */
   private String prepareEventPropertyPath(String pathStatement, LifecycleEventType eventType, String uniqueEventVar) {
@@ -627,9 +647,36 @@ public class LifecycleTaskService {
   private DataManifest<List<Map<String, Object>>> executeOccurrenceQuery(String entityType,
       String[] lifecycleStatements,
       LifecycleEventType eventType, PaginationState pagination) {
+    // ID retrieval and handling
     Queue<List<String>> ids = this.getService.getAllIds(entityType, lifecycleStatements[0], pagination);
+    // Return early if nothing if found
+    if (ids.isEmpty()) {
+      return new DataManifest<>(new ArrayList<>(), new ArrayList<>());
+    }
+
+    List<List<String>> originalIds = new ArrayList<>(ids); // make it a persistent copy
+
+    // Initialise separate queues for primary entity and events
+    Queue<List<String>> idQueue = new LinkedList<>();
+    Queue<List<String>> eventIdQueue = new LinkedList<>();
+
+    for (List<String> pair : originalIds) {
+      if (pair != null && pair.size() >= 2) {
+        idQueue.add(Collections.singletonList(pair.get(0)));
+        eventIdQueue.add(Collections.singletonList(pair.get(1)));
+      }
+    }
+
+    // Query for primary entity
+    Set<ColumnMetaPayload> entityVarSequences = new LinkedHashSet<>(this.taskEntityColumnMeta);
+    String entityQuery = lifecycleStatements[1];
+    DataManifest<Queue<SparqlBinding>> resultsManifest = this.getService.getInstances(entityType, true, idQueue,
+        entityQuery, new ArrayList<>(entityVarSequences));
+
+    // Query for event
+
     Set<ColumnMetaPayload> varSequences = new LinkedHashSet<>(this.taskColumnMeta);
-    String addQuery = lifecycleStatements[1];
+    String addQuery = lifecycleStatements[2];
     addQuery += this.parseEventOccurrenceQuery(LifecycleEventType.SERVICE_ORDER_DISPATCHED, varSequences);
     if (eventType.equals(LifecycleEventType.ACTIVE_SERVICE) || eventType.equals(LifecycleEventType.SERVICE_ACCRUAL)) {
       addQuery += this.parseEventOccurrenceQuery(LifecycleEventType.SERVICE_EXECUTION, varSequences);
@@ -637,12 +684,100 @@ public class LifecycleTaskService {
       addQuery += this.parseEventOccurrenceQuery(LifecycleEventType.SERVICE_INCIDENT_REPORT, varSequences);
       addQuery += this.parseEventOccurrenceQuery(LifecycleEventType.SERVICE_EXEMPT, varSequences);
     }
-    DataManifest<Queue<SparqlBinding>> resultsManifest = this.getService.getInstances(entityType, true, ids, addQuery,
-        new ArrayList<>(varSequences));
-    return new DataManifest<>(resultsManifest.data().stream()
-        .map(binding -> this.lifecycleQueryService.parseLifecycleBinding(binding.get()))
-        .toList(),
-        resultsManifest.columns());
+    String occurrenceQueryString = this.genOccurrenceEventQueryStatement(varSequences, eventIdQueue, addQuery);
+    Queue<SparqlBinding> occurrenceResultQueue = this.getService.getInstances(occurrenceQueryString);
+
+    // Combine results from entity query and event query
+
+    // Convert results to map with IDs as the keys
+    Map<String, Map<String, Object>> primaryById = mapBindingsById(resultsManifest.data(), QueryResource.ID_KEY);
+    Map<String, Map<String, Object>> eventById = mapBindingsById(occurrenceResultQueue,
+        QueryResource.EVENT_ID_VAR.getVarName());
+
+    // Merge data of primary entity and event    
+    List<Map<String, Object>> mergedData = new ArrayList<>();
+    for (List<String> pair : originalIds) {
+      if (pair.size() < 2) {
+        continue;
+      }
+      Map<String, Object> mergedRow = new LinkedHashMap<>();
+      Map<String, Object> primaryRow = primaryById.get(pair.get(0));
+      Map<String, Object> eventRow = eventById.get(pair.get(1));
+      if (primaryRow != null) {
+        mergedRow.putAll(primaryRow);
+      }
+      if (eventRow != null) {
+        mergedRow.putAll(eventRow);
+      }
+      if (!mergedRow.isEmpty()) {
+        mergedData.add(mergedRow);
+      }
+    }
+
+    // Merge column metadata
+    List<ColumnMetaPayload> mergedColumns = new ArrayList<>(resultsManifest.columns());
+    mergedColumns.addAll(varSequences);
+
+    return new DataManifest<>(mergedData, mergedColumns);
+  }
+
+  private Map<String, Map<String, Object>> mapBindingsById(Collection<SparqlBinding> bindings, String idKey) {
+    return bindings.stream().map(binding -> Map.entry(
+        binding.getFieldValue(idKey),
+        this.lifecycleQueryService.parseLifecycleBinding(binding.get())))
+        .collect(Collectors.toMap(
+            Map.Entry::getKey,
+            Map.Entry::getValue,
+            (existing, replacement) -> existing,
+            LinkedHashMap::new));
+  }
+
+  private String genOccurrenceEventQueryStatement(Set<ColumnMetaPayload> varSequences,
+      Queue<List<String>> eventIdQueue, String addQuery) {
+    // Initialise blank template
+    String occurrenceQueryString = QueryResource.getSelectQuery().getQueryString();
+    occurrenceQueryString = occurrenceQueryString.substring(0,
+        occurrenceQueryString.indexOf("WHERE {") + "WHERE {".length());
+
+    // Append the core event anchor triple statements
+    String eventAnchorString = "?order_event <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> "
+        +
+        "<https://www.theworldavatar.com/kg/ontoservice/OrderReceivedEvent>;" +
+        "<https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/hasEventDate> ?event_date." +
+        " BIND(xsd:date(?event_date) AS ?date)" +
+        "?event_id a <https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/ContractLifecycleEventOccurrence>; "
+        +
+        " <https://www.omg.org/spec/Commons/DatesAndTimes/succeeds>* ?order_event.";
+    occurrenceQueryString += eventAnchorString;
+
+    varSequences.add(new ColumnMetaPayload(QueryResource.EVENT_ID_VAR.getVarName(), QueryResource.LITERAL_TYPE,
+        ShaclResource.XSD_STRING)); // Add event ID column meta
+
+    // Generate select variable clause
+    List<String> selectVariables = new ArrayList<>();
+    for (ColumnMetaPayload column : varSequences) {
+      selectVariables.add(QueryResource.genVariable(column.value()).getQueryString());
+    }
+
+    occurrenceQueryString = occurrenceQueryString.replace("SELECT *",
+        "SELECT DISTINCT " + String.join(" ", selectVariables));
+    occurrenceQueryString = occurrenceQueryString.replace("?status", "?event ?event_status"); // Specific to event
+                                                                                              // status
+
+    // Generate value statement to include event IDs
+    List<String> eventIds = new ArrayList<>();
+    while (!eventIdQueue.isEmpty()) {
+      List<String> item = eventIdQueue.poll();
+      if (item != null && !item.isEmpty()) {
+        eventIds.add("<" + item.get(0) + ">");
+      }
+    }
+
+    occurrenceQueryString = occurrenceQueryString + "\n" + addQuery + "\n";
+    occurrenceQueryString += QueryResource.values(eventIds, QueryResource.EVENT_ID_VAR.getVarName());
+    occurrenceQueryString += "}";
+
+    return occurrenceQueryString;
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -657,24 +657,25 @@ public class LifecycleTaskService {
     List<List<String>> originalIds = new ArrayList<>(ids); // make it a persistent copy
 
     // Initialise separate queues for primary entity and events
-    Queue<List<String>> idQueue = new LinkedList<>();
-    Queue<List<String>> eventIdQueue = new LinkedList<>();
+    Set<List<String>> uniqueIdSet = new LinkedHashSet<>();
+    Set<List<String>> uniqueEventIdSet = new LinkedHashSet<>();
 
     for (List<String> pair : originalIds) {
       if (pair != null && pair.size() >= 2) {
-        idQueue.add(Collections.singletonList(pair.get(0)));
-        eventIdQueue.add(Collections.singletonList(pair.get(1)));
+        uniqueIdSet.add(Collections.singletonList(pair.get(0)));
+        uniqueEventIdSet.add(Collections.singletonList(pair.get(1)));
       }
     }
 
-    // Query for primary entity
+    // Convert back to queue
+    Queue<List<String>> idQueue = new LinkedList<>(uniqueIdSet);
+    Queue<List<String>> eventIdQueue = new LinkedList<>(uniqueEventIdSet);
+
+    // Query preparation for primary entity
     Set<ColumnMetaPayload> entityVarSequences = new LinkedHashSet<>(this.taskEntityColumnMeta);
     String entityQuery = lifecycleStatements[1];
-    // DataManifest<Queue<SparqlBinding>> resultsManifest =
-    // this.getService.getInstances(entityType, true, idQueue,
-    // entityQuery, new ArrayList<>(entityVarSequences));
 
-    // Query for event
+    // Query preparation for event
 
     Set<ColumnMetaPayload> varSequences = new LinkedHashSet<>(this.taskColumnMeta);
     String addQuery = lifecycleStatements[2];
@@ -686,9 +687,8 @@ public class LifecycleTaskService {
       addQuery += this.parseEventOccurrenceQuery(LifecycleEventType.SERVICE_EXEMPT, varSequences);
     }
     String occurrenceQueryString = this.genOccurrenceEventQueryStatement(varSequences, eventIdQueue, addQuery);
-    // Queue<SparqlBinding> occurrenceResultQueue =
-    // this.getService.getInstances(occurrenceQueryString);
 
+    // Execute primary entity and event queries in parallel
     List<DataManifest<Queue<SparqlBinding>>> parallelResults = ParallelTaskExecutor.execDualParallelQueries(
         // Query for entity
         () -> this.getService.getInstances(entityType, true, idQueue, entityQuery, new ArrayList<>(entityVarSequences)),
@@ -698,7 +698,7 @@ public class LifecycleTaskService {
           return new DataManifest<>(queue, new ArrayList<>(varSequences));
         });
 
-    // Unpack your assignments right below
+    // Unpack query results
     DataManifest<Queue<SparqlBinding>> resultsManifest = parallelResults.get(0);
     Queue<SparqlBinding> occurrenceResultQueue = parallelResults.get(1).data();
 

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.57.1";
+  private static final String API_VERSION = "1.58.0-decouple-event-query-SNAPSHOT";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.58.0-decouple-event-query-SNAPSHOT";
+  private static final String API_VERSION = "1.58.0";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.57.1
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.58.0-decouple-event-query-SNAPSHOT
     build:
       context: ..
       target: test

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.58.0-decouple-event-query-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.58.0
     build:
       context: ..
       target: test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.58.0-decouple-event-query-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.58.0
     build:
       context: ..
       target: agent

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.57.1
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.58.0-decouple-event-query-SNAPSHOT
     build:
       context: ..
       target: agent

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.1",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.0-decouple-event-query-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.0-decouple-event-query-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.0",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.57.1",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.0-decouple-event-query-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.0-decouple-event-query-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.0",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",


### PR DESCRIPTION
Modified the query behaviour of tasks with full detail. New behaviour:

- Based on filtering constraints, find the relevant IDs of contracts and events
- Run queries for contract properties and event properties **independently in parallel**
- Merge the query results back into a single instance