### PR TITLE
Ctlao/300 lifecycle schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.58.2
+
+- Fixed schedule update
+
 ## 1.58.1
 
 - Code optimisations

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.58.2-schedule-id-SNAPSHOT</version>
+	<version>1.58.2</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.58.1</version>
+	<version>1.58.2-schedule-id-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/src/main/resources/jsonld/lifecycle_ad_hoc_schedule.jsonld
+++ b/agent/src/main/resources/jsonld/lifecycle_ad_hoc_schedule.jsonld
@@ -159,6 +159,10 @@
           "prefix": "https://www.theworldavatar.io/kg/agreement/schedule/"
         },
         "@type": "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/AdHocSchedule",
+        "http://purl.org/dc/terms/identifier": {
+          "@replace": "id",
+          "@type": "literal"
+        },
         "https://www.omg.org/spec/Commons/DatesAndTimes/hasStartDate": {
           "@id": {
             "@replace": "id",

--- a/agent/src/main/resources/jsonld/lifecycle_regular_schedule.jsonld
+++ b/agent/src/main/resources/jsonld/lifecycle_regular_schedule.jsonld
@@ -159,6 +159,10 @@
           "prefix": "https://www.theworldavatar.io/kg/agreement/schedule/"
         },
         "@type": "https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/RegularSchedule",
+        "http://purl.org/dc/terms/identifier": {
+          "@replace": "id",
+          "@type": "literal"
+        },
         "https://www.omg.org/spec/Commons/DatesAndTimes/hasStartDate": {
           "@id": {
             "@replace": "id",

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.58.2-schedule-id-SNAPSHOT";
+  private static final String API_VERSION = "1.58.2";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.58.1";
+  private static final String API_VERSION = "1.58.2-schedule-id-SNAPSHOT";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.58.1
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.58.2-schedule-id-SNAPSHOT
     build:
       context: ..
       target: test

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.58.2-schedule-id-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.58.2
     build:
       context: ..
       target: test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.58.1
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.58.2-schedule-id-SNAPSHOT
     build:
       context: ..
       target: agent

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.58.2-schedule-id-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.58.2
     build:
       context: ..
       target: agent

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.2-schedule-id-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.2",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.1",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.2-schedule-id-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.2-schedule-id-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.2",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.1",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.58.2-schedule-id-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",


### PR DESCRIPTION
Explicitly add dc-term:identifier for schedule instances in lifecycle-schedule JSON-LD files.

This allows schedule to be updated correctly.