### PR TITLE
Ctlao/close task speed hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.62.0
+
+- Improved performance of event query
+
 ## 1.61.1
 
 - Fixed WKT regex

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.62.0-closed-task-speed-hotfix-SNAPSHOT</version>
+	<version>1.62.0</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.61.1</version>
+	<version>1.62.0-closed-task-speed-hotfix-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/src/main/java/com/cmclinnovations/agent/template/LifecycleQueryFactory.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/template/LifecycleQueryFactory.java
@@ -246,12 +246,16 @@ public class LifecycleQueryFactory {
                 + "MINUS{" + eventIdVar + " ^<https://www.omg.org/spec/Commons/DatesAndTimes/succeeds> ?any_event}");
         // Statements to link order event and latest event
         // This is minimised for performance, relying on injection of event ID
-        results.put(LifecycleResource.EVENT_LIFECYCLE_RESOURCE, eventChainStatements
-                + "OPTIONAL {" + ACCRUAL_EVENT_QUERY_STATEMENT + " .\n"
-                + "{" + INVOICED_QUERY_STATEMENT + " . BIND(\"" + BillingResource.INVOICE_RESOURCE
-                + "\" AS ?prev_event)} UNION\n" + "{" + eventIdVar
-                + " <https://www.omg.org/spec/Commons/DatesAndTimes/succeeds>/<https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> ?prev_event .\n"
-                + "FILTER NOT EXISTS {" + INVOICED_QUERY_STATEMENT + " .}}}\n");
+        String previousEventStatements = "";
+        if (eventType.equals(LifecycleEventType.ACTIVE_SERVICE)
+                || eventType.equals(LifecycleEventType.SERVICE_ACCRUAL)) {
+            previousEventStatements = "OPTIONAL {" + ACCRUAL_EVENT_QUERY_STATEMENT + " .\n"
+                    + "{" + INVOICED_QUERY_STATEMENT + " . BIND(\"" + BillingResource.INVOICE_RESOURCE
+                    + "\" AS ?prev_event)} UNION\n" + "{" + eventIdVar
+                    + " <https://www.omg.org/spec/Commons/DatesAndTimes/succeeds>/<https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> ?prev_event .\n"
+                    + "FILTER NOT EXISTS {" + INVOICED_QUERY_STATEMENT + " .}}}\n";
+        }
+        results.put(LifecycleResource.EVENT_LIFECYCLE_RESOURCE, eventChainStatements + previousEventStatements);
         results.put(LifecycleResource.EVENT_KEY,
                 eventIdVar
                         + " <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> ?temp_event."

--- a/agent/src/main/java/com/cmclinnovations/agent/template/LifecycleQueryFactory.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/template/LifecycleQueryFactory.java
@@ -224,38 +224,34 @@ public class LifecycleQueryFactory {
         } else {
             eventTargetStatements = UNCLOSED_QUERY_STATEMENTS;
         }
+        // Statements to link contract to order events
         String lifecyclePrefix = filterContractStatement
                 + "?iri <https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/hasLifecycle>/<https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/Lifecycles/hasStage> ?stage."
                 + "?stage <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> <"
                 + LifecycleEventType.SERVICE_EXECUTION.getStage() + ">;"
                 + "<https://www.omg.org/spec/Commons/Collections/comprises> ?order_event.";
-        String eventCommonString = "?order_event <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> "
+        // Statements to link order events to the target event and its date
+        String eventChainStatements = "?order_event <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> "
                 + Rdf.iri(LifecycleResource.EVENT_ORDER_RECEIVED).getQueryString()
                 + ";<https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/hasEventDate> "
                 + eventDatePlaceholderVar
                 + ". BIND(xsd:date(" + eventDatePlaceholderVar + ") AS " + eventDateVar
-                + ")"
-                + eventIdVar
+                + ")" + eventIdVar
                 + " a <https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/ContractLifecycleEventOccurrence>;"
                 + " <https://www.omg.org/spec/Commons/DatesAndTimes/succeeds>* ?order_event.";
-        String lifecycleSuffix = eventCommonString
-                + eventTargetStatements
-                + filterDateStatement
-                // Event must be the last in the chain ie no other events will succeed
-                // it
-                + "MINUS{" + eventIdVar
-                + " ^<https://www.omg.org/spec/Commons/DatesAndTimes/succeeds> ?any_event}";
-        results.put(LifecycleResource.LIFECYCLE_RESOURCE, lifecyclePrefix + lifecycleSuffix);
-        // alternative in attempt to improve performance
-        String optimizedEventTargetStatements = eventCommonString
-                + "OPTIONAL {" + eventIdVar + " <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> <https://www.theworldavatar.com/kg/ontoservice/ServiceAccrualEvent> .\n"
-                + "{?invoice <https://purl.org/p2p-o/invoice#hasInvoiceReference>/<https://www.omg.org/spec/Commons/Documents/isAbout> "
-                + eventIdVar + " . BIND(\"invoice\" AS ?prev_event)} UNION\n"
-                + "{" + eventIdVar
+        // Statements to retrieve essential contract and event instances
+        results.put(LifecycleResource.LIFECYCLE_RESOURCE, lifecyclePrefix
+                + eventChainStatements + eventTargetStatements+ filterDateStatement
+                // Event must be the last in the chain i.e. no successor event
+                + "MINUS{" + eventIdVar + " ^<https://www.omg.org/spec/Commons/DatesAndTimes/succeeds> ?any_event}");
+        // Statements to link order event and latest event
+        // This is minimised for performance, relying on injection of event ID
+        results.put(LifecycleResource.EVENT_LIFECYCLE_RESOURCE, eventChainStatements
+                + "OPTIONAL {" + ACCRUAL_EVENT_QUERY_STATEMENT + " .\n"
+                + "{" + INVOICED_QUERY_STATEMENT + " . BIND(\"" + BillingResource.INVOICE_RESOURCE
+                + "\" AS ?prev_event)} UNION\n" + "{" + eventIdVar
                 + " <https://www.omg.org/spec/Commons/DatesAndTimes/succeeds>/<https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> ?prev_event .\n"
-                + "FILTER NOT EXISTS {?invoice <https://purl.org/p2p-o/invoice#hasInvoiceReference>/<https://www.omg.org/spec/Commons/Documents/isAbout> "
-                + eventIdVar + " .}}}\n";
-        results.put(LifecycleResource.EVENT_LIFECYCLE_RESOURCE, optimizedEventTargetStatements);
+                + "FILTER NOT EXISTS {" + INVOICED_QUERY_STATEMENT + " .}}}\n");
         results.put(LifecycleResource.EVENT_KEY,
                 eventIdVar
                         + " <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> ?temp_event."
@@ -263,7 +259,6 @@ public class LifecycleQueryFactory {
                         + eventStatusVar
                         + "} BIND(CONCAT(STR(?temp_event),IF(BOUND(?event_status),CONCAT(\";\",STR(?event_status)),"
                         + "IF(BOUND(?prev_event),CONCAT(\";\",STR(?prev_event)),\"\"))) AS " + eventVar + ")");
-        
         results.put(LifecycleResource.LAST_MODIFIED_KEY, eventIdVar
                 + "<https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/hasEventDate> "
                 + lastModifiedVar + ShaclResource.FULL_STOP);

--- a/agent/src/main/java/com/cmclinnovations/agent/template/LifecycleQueryFactory.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/template/LifecycleQueryFactory.java
@@ -229,7 +229,7 @@ public class LifecycleQueryFactory {
                 + "?stage <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> <"
                 + LifecycleEventType.SERVICE_EXECUTION.getStage() + ">;"
                 + "<https://www.omg.org/spec/Commons/Collections/comprises> ?order_event.";
-        String lifecycleSuffix = "?order_event <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> "
+        String eventCommonString = "?order_event <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> "
                 + Rdf.iri(LifecycleResource.EVENT_ORDER_RECEIVED).getQueryString()
                 + ";<https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/hasEventDate> "
                 + eventDatePlaceholderVar
@@ -237,7 +237,8 @@ public class LifecycleQueryFactory {
                 + ")"
                 + eventIdVar
                 + " a <https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/ContractLifecycleEventOccurrence>;"
-                + " <https://www.omg.org/spec/Commons/DatesAndTimes/succeeds>* ?order_event."
+                + " <https://www.omg.org/spec/Commons/DatesAndTimes/succeeds>* ?order_event.";
+        String lifecycleSuffix = eventCommonString
                 + eventTargetStatements
                 + filterDateStatement
                 // Event must be the last in the chain ie no other events will succeed
@@ -245,7 +246,16 @@ public class LifecycleQueryFactory {
                 + "MINUS{" + eventIdVar
                 + " ^<https://www.omg.org/spec/Commons/DatesAndTimes/succeeds> ?any_event}";
         results.put(LifecycleResource.LIFECYCLE_RESOURCE, lifecyclePrefix + lifecycleSuffix);
-        results.put(LifecycleResource.EVENT_LIFECYCLE_RESOURCE, lifecycleSuffix);
+        // alternative in attempt to improve performance
+        String optimizedEventTargetStatements = eventCommonString
+                + "OPTIONAL {" + eventIdVar + " <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> <https://www.theworldavatar.com/kg/ontoservice/ServiceAccrualEvent> .\n"
+                + "{?invoice <https://purl.org/p2p-o/invoice#hasInvoiceReference>/<https://www.omg.org/spec/Commons/Documents/isAbout> "
+                + eventIdVar + " . BIND(\"invoice\" AS ?prev_event)} UNION\n"
+                + "{" + eventIdVar
+                + " <https://www.omg.org/spec/Commons/DatesAndTimes/succeeds>/<https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> ?prev_event .\n"
+                + "FILTER NOT EXISTS {?invoice <https://purl.org/p2p-o/invoice#hasInvoiceReference>/<https://www.omg.org/spec/Commons/Documents/isAbout> "
+                + eventIdVar + " .}}}\n";
+        results.put(LifecycleResource.EVENT_LIFECYCLE_RESOURCE, optimizedEventTargetStatements);
         results.put(LifecycleResource.EVENT_KEY,
                 eventIdVar
                         + " <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/exemplifies> ?temp_event."
@@ -253,6 +263,7 @@ public class LifecycleQueryFactory {
                         + eventStatusVar
                         + "} BIND(CONCAT(STR(?temp_event),IF(BOUND(?event_status),CONCAT(\";\",STR(?event_status)),"
                         + "IF(BOUND(?prev_event),CONCAT(\";\",STR(?prev_event)),\"\"))) AS " + eventVar + ")");
+        
         results.put(LifecycleResource.LAST_MODIFIED_KEY, eventIdVar
                 + "<https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/Occurrences/hasEventDate> "
                 + lastModifiedVar + ShaclResource.FULL_STOP);

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.61.1";
+  private static final String API_VERSION = "1.62.0-closed-task-speed-hotfix-SNAPSHOT";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.62.0-closed-task-speed-hotfix-SNAPSHOT";
+  private static final String API_VERSION = "1.62.0";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.61.1
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.62.0-closed-task-speed-hotfix-SNAPSHOT
     build:
       context: ..
       target: test

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.62.0-closed-task-speed-hotfix-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.62.0
     build:
       context: ..
       target: test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.61.1
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.62.0-closed-task-speed-hotfix-SNAPSHOT
     build:
       context: ..
       target: agent

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.62.0-closed-task-speed-hotfix-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.62.0
     build:
       context: ..
       target: agent

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.61.1",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.0-closed-task-speed-hotfix-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.0-closed-task-speed-hotfix-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.0",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.61.1",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.0-closed-task-speed-hotfix-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.0-closed-task-speed-hotfix-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.0",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",


### PR DESCRIPTION
Simplified the event lifecycle query statement only when trying to get all properties needed. Pagination query should be unaffected.