### PR TITLE
Ctlao/event filter improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.62.1
+
+- Improved performance of filtering event properties
+
 ## 1.62.0
 
 - Improved performance of event query

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.62.0</version>
+	<version>1.62.1-event-filter-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.62.1-event-filter-SNAPSHOT</version>
+	<version>1.62.1</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -418,30 +418,22 @@ public class LifecycleTaskService {
       }
 
       String propertyValueVar = QueryResource.genVariable(propertyKey).getQueryString();
-      List<String> unifiedEventBlocks = new ArrayList<>();
       List<String> eventVarsInvolved = new ArrayList<>();
-
-      for (Map.Entry<LifecycleEventType, String> entry : matchedEvents.entrySet()) {
+      String combinedGraphPath;
+      if (matchedEvents.size() == 1) {
+        Map.Entry<LifecycleEventType, String> entry = matchedEvents.entrySet().iterator().next();
         LifecycleEventType currentEventType = entry.getKey();
-
-        // Dynamically build a completely unique variable name for this specific
-        // property block
         String uniqueVarStr = currentEventType.getId() + "_event_" + propertyKey;
         String uniqueEventVar = QueryResource.genVariable(uniqueVarStr).getQueryString();
         eventVarsInvolved.add(uniqueEventVar);
 
         String innerPathContent = prepareEventPropertyPath(entry.getValue(), currentEventType, uniqueEventVar);
-        String fullEventPropertyPath = "{ " + innerPathContent + " }";
-        unifiedEventBlocks.add(fullEventPropertyPath);
-
+        combinedGraphPath = QueryResource.union("{ " + innerPathContent + " }");
+      } else {
+        String sharedEventVar = QueryResource.genVariable(propertyKey + "_event").getQueryString();
+        eventVarsInvolved.add(sharedEventVar);
+        combinedGraphPath = prepareSharedEventPropertyPath(matchedEvents, sharedEventVar);
       }
-
-      if (unifiedEventBlocks.isEmpty()) {
-        continue;
-      }
-
-      String combinedGraphPath = QueryResource.union(unifiedEventBlocks.get(0),
-          unifiedEventBlocks.stream().skip(1).toArray(String[]::new));
 
       Set<String> filterValues = serviceEventFilters.get(propertyKey);
       if (filterValues == null || filterValues.isEmpty()) {
@@ -531,23 +523,21 @@ public class LifecycleTaskService {
     if (isLookupMode) {
       Map<LifecycleEventType, String> matchedEvents = propertyToEventMappings.get(field);
       if (matchedEvents != null && !matchedEvents.isEmpty()) {
-        List<String> unifiedEventBlocks = new ArrayList<>();
-
-        for (Map.Entry<LifecycleEventType, String> entry : matchedEvents.entrySet()) {
+        String combinedGraphPath;
+        if (matchedEvents.size() == 1) {
+          Map.Entry<LifecycleEventType, String> entry = matchedEvents.entrySet().iterator().next();
           LifecycleEventType currentEventType = entry.getKey();
           String lookupVarStr = currentEventType.getId() + "_event_lookup";
           String lookupEventVar = QueryResource.genVariable(lookupVarStr).getQueryString();
 
           String innerPathContent = this.prepareEventPropertyPath(entry.getValue(), currentEventType, lookupEventVar);
-          unifiedEventBlocks.add("{ " + innerPathContent + " }");
+          combinedGraphPath = QueryResource.union("{ " + innerPathContent + " }");
+        } else {
+          String sharedEventVar = QueryResource.genVariable(field + "_event_lookup").getQueryString();
+          combinedGraphPath = prepareSharedEventPropertyPath(matchedEvents, sharedEventVar);
         }
 
-        if (!unifiedEventBlocks.isEmpty()) {
-          String combinedGraphPath = QueryResource.union(unifiedEventBlocks.get(0),
-              unifiedEventBlocks.stream().skip(1).toArray(String[]::new));
-
-          finalQueryAccumulator.append(QueryResource.optional(combinedGraphPath)).append("\n");
-        }
+        finalQueryAccumulator.append(QueryResource.optional(combinedGraphPath)).append("\n");
       }
     }
 
@@ -574,6 +564,34 @@ public class LifecycleTaskService {
     String finalizedPath = replacedPath.endsWith(".") ? replacedPath : replacedPath + " .";
 
     return anchor + " " + finalizedPath;
+  }
+
+  /**
+   * Prepares a shared occurrence path followed by event-specific property
+   * branches.
+   */
+  private String prepareSharedEventPropertyPath(Map<LifecycleEventType, String> matchedEvents,
+      String sharedEventVar) {
+    List<String> eventPropertyBranches = matchedEvents.entrySet().stream()
+        .map(entry -> this.prepareEventPropertyBranch(entry.getValue(), entry.getKey(), sharedEventVar))
+        .toList();
+    String combinedEventBranches = QueryResource.union(eventPropertyBranches.get(0),
+        eventPropertyBranches.stream().skip(1).toArray(String[]::new));
+    String sharedOccurrencePath = sharedEventVar
+        + " <https://www.omg.org/spec/Commons/DatesAndTimes/succeeds>* ?order_event.";
+    return sharedOccurrencePath + " " + combinedEventBranches;
+  }
+
+  /**
+   * Prepares an event type and its property path against a shared event variable.
+   */
+  private String prepareEventPropertyBranch(String pathStatement, LifecycleEventType eventType,
+      String sharedEventVar) {
+    String eventTypeStatement = sharedEventVar + " <" + LifecycleResource.EXEMPLIFIES_RELATIONS + "> <"
+        + eventType.getEvent() + ">.";
+    String replacedPath = pathStatement.replace(QueryResource.IRI_VAR.getQueryString(), sharedEventVar).trim();
+    String finalizedPath = replacedPath.endsWith(".") ? replacedPath : replacedPath + " .";
+    return eventTypeStatement + " " + finalizedPath;
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -428,7 +428,7 @@ public class LifecycleTaskService {
         eventVarsInvolved.add(uniqueEventVar);
 
         String innerPathContent = prepareEventPropertyPath(entry.getValue(), currentEventType, uniqueEventVar);
-        combinedGraphPath = QueryResource.union("{ " + innerPathContent + " }");
+        combinedGraphPath = innerPathContent;
       } else {
         String sharedEventVar = QueryResource.genVariable(propertyKey + "_event").getQueryString();
         eventVarsInvolved.add(sharedEventVar);
@@ -440,23 +440,30 @@ public class LifecycleTaskService {
         continue;
       }
 
+      // For single-event value-only filters, OPTIONAL keeps Blazegraph from
+      // reordering this path ahead of the bound order event. The following FILTER
+      // rejects unbound values, so the path remains mandatory in effect.
+      String valueOnlyGraphPath = matchedEvents.size() == 1
+          ? QueryResource.optional(combinedGraphPath)
+          : combinedGraphPath;
+
       StringBuilder filterClauseBuilder = new StringBuilder();
 
       // Handle value injection for date type
       if (filterValues.contains(LifecycleResource.DATE_KEY)) {
-        filterClauseBuilder.append("{ ").append(combinedGraphPath).append(" }\n");
+        filterClauseBuilder.append(valueOnlyGraphPath).append("\n");
 
         String dateFiltersStr = QueryResource.genDateFilterExpression(propertyKey, filterValues);
         filterClauseBuilder.append(dateFiltersStr).append("\n");
       } else if (filterValues.contains(QueryResource.TIME_TYPE)) {
         // Handle value injection for time type
-        filterClauseBuilder.append("{ ").append(combinedGraphPath).append(" }\n");
+        filterClauseBuilder.append(valueOnlyGraphPath).append("\n");
 
         String timeFilterExpression = QueryResource.genTimeFilterExpression(propertyKey, filterValues);
         filterClauseBuilder.append(timeFilterExpression).append("\n");
       } else if (filterValues.contains(QueryResource.NUMERIC_TYPE)) {
         // Handle value injection for numerical type
-        filterClauseBuilder.append("{ ").append(combinedGraphPath).append(" }\n");
+        filterClauseBuilder.append(valueOnlyGraphPath).append("\n");
 
         String numericalFilterExpression = QueryResource.genNumericalFilterExpression(propertyKey, filterValues);
         filterClauseBuilder.append(numericalFilterExpression).append("\n");
@@ -493,7 +500,7 @@ public class LifecycleTaskService {
         }
         // Strict selection with explicit values only
         else {
-          filterClauseBuilder.append("{ ").append(combinedGraphPath).append(" }\n");
+          filterClauseBuilder.append(valueOnlyGraphPath).append("\n");
           String strictExpr = propertyValueVar + " IN (" + valuesListString + ")";
           filterClauseBuilder.append(QueryResource.filter(strictExpr)).append("\n");
         }
@@ -531,7 +538,7 @@ public class LifecycleTaskService {
           String lookupEventVar = QueryResource.genVariable(lookupVarStr).getQueryString();
 
           String innerPathContent = this.prepareEventPropertyPath(entry.getValue(), currentEventType, lookupEventVar);
-          combinedGraphPath = QueryResource.union("{ " + innerPathContent + " }");
+          combinedGraphPath = innerPathContent;
         } else {
           String sharedEventVar = QueryResource.genVariable(field + "_event_lookup").getQueryString();
           combinedGraphPath = prepareSharedEventPropertyPath(matchedEvents, sharedEventVar);

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.62.0";
+  private static final String API_VERSION = "1.62.1-event-filter-SNAPSHOT";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.62.1-event-filter-SNAPSHOT";
+  private static final String API_VERSION = "1.62.1";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.62.1-event-filter-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.62.1
     build:
       context: ..
       target: test

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.62.0
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.62.1-event-filter-SNAPSHOT
     build:
       context: ..
       target: test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.62.0
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.62.1-event-filter-SNAPSHOT
     build:
       context: ..
       target: agent

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.62.1-event-filter-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.62.1
     build:
       context: ..
       target: agent

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.1-event-filter-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.1",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.0",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.1-event-filter-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.1-event-filter-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.1",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.0",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.62.1-event-filter-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",


### PR DESCRIPTION
Re-factored filtering on event properties:

- Handle properties with single event type and properties with multiple event types separately
- For properties with single event type, always wrap in OPTIONAL. This forces the join order.