### PR TITLE
Bulk assign in batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 1.65.0
+
+- Improved bulk task assignment by batching previous event lookup, deletion and instantiation
+- Batched activity logging after all task updates succeed
+
 # 1.64.4
 
 - Substituted hard-coded branch inference logic with custom SPARQL query

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.64.4</version>
+	<version>1.65.0-batch-bulk-assign-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.cmclinnovations</groupId>
 	<artifactId>vis-backend-agent</artifactId>
-	<version>1.65.0-batch-bulk-assign-SNAPSHOT</version>
+	<version>1.65.0</version>
 	<packaging>war</packaging>
 	<name>vis-backend-agent</name>
 	<url />

--- a/agent/src/main/java/com/cmclinnovations/agent/LifecycleController.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/LifecycleController.java
@@ -34,6 +34,7 @@ import com.cmclinnovations.agent.service.GetService;
 import com.cmclinnovations.agent.service.UpdateService;
 import com.cmclinnovations.agent.service.application.BillingService;
 import com.cmclinnovations.agent.service.application.LifecycleContractService;
+import com.cmclinnovations.agent.service.application.LifecycleTaskBatchService;
 import com.cmclinnovations.agent.service.application.LifecycleTaskService;
 import com.cmclinnovations.agent.service.core.ConcurrencyService;
 import com.cmclinnovations.agent.service.core.DateTimeService;
@@ -55,6 +56,7 @@ public class LifecycleController {
   private final DateTimeService dateTimeService;
   private final BillingService billingService;
   private final LifecycleContractService lifecycleContractService;
+  private final LifecycleTaskBatchService lifecycleTaskBatchService;
   private final LifecycleTaskService lifecycleTaskService;
   private final ResponseEntityBuilder responseEntityBuilder;
 
@@ -63,7 +65,8 @@ public class LifecycleController {
   public LifecycleController(ConcurrencyService concurrencyService, AddService addService, GetService getService,
       DeleteService deleteService, UpdateService updateService, DateTimeService dateTimeService,
       BillingService billingService, LifecycleContractService lifecycleContractService,
-      LifecycleTaskService lifecycleTaskService, ResponseEntityBuilder responseEntityBuilder) {
+      LifecycleTaskBatchService lifecycleTaskBatchService, LifecycleTaskService lifecycleTaskService,
+      ResponseEntityBuilder responseEntityBuilder) {
     this.concurrencyService = concurrencyService;
     this.addService = addService;
     this.getService = getService;
@@ -72,6 +75,7 @@ public class LifecycleController {
     this.dateTimeService = dateTimeService;
     this.billingService = billingService;
     this.lifecycleContractService = lifecycleContractService;
+    this.lifecycleTaskBatchService = lifecycleTaskBatchService;
     this.lifecycleTaskService = lifecycleTaskService;
     this.responseEntityBuilder = responseEntityBuilder;
   }
@@ -394,20 +398,11 @@ public class LifecycleController {
     });
   }
 
-  @PutMapping("/service/dispatch/bulk")
-  public ResponseEntity<StandardApiResponse<?>> bulkUpdateTaskEventDetails(
+  @PutMapping("/service/{type}/bulk")
+  public ResponseEntity<StandardApiResponse<?>> bulkUpdateTaskEventDetails(@PathVariable String type,
       @RequestBody Map<String, List<Map<String, Object>>> params) {
-    try {
-      params.get("items")
-          .forEach(item -> this.updateTaskEventDetails(LifecycleEventType.SERVICE_ORDER_DISPATCHED.getId(), item));
-    } catch (IllegalArgumentException _) {
-      LOGGER.error("Error encountered while bulk assigning dispatch details! Read error logs for more details");
-      return this.responseEntityBuilder.error(
-          LocalisationTranslator.getMessage(LocalisationResource.ERROR_DISPATCH_PARTIAL_KEY),
-          HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-    return this.responseEntityBuilder
-        .success("task", LocalisationTranslator.getMessage(LocalisationResource.SUCCESS_CONTRACT_TASK_BULK_ASSIGN_KEY));
+    return this.concurrencyService.executeInWriteLock(LifecycleResource.TASK_RESOURCE,
+        () -> this.lifecycleTaskBatchService.updateTaskEventDetails(type, params.get("items")));
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/LifecycleController.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/LifecycleController.java
@@ -401,6 +401,7 @@ public class LifecycleController {
   @PutMapping("/service/{type}/bulk")
   public ResponseEntity<StandardApiResponse<?>> bulkUpdateTaskEventDetails(@PathVariable String type,
       @RequestBody Map<String, List<Map<String, Object>>> params) {
+    // Hold one task lock across dispatch replacement and subsequent activity logging.
     return this.concurrencyService.executeInWriteLock(LifecycleResource.TASK_RESOURCE,
         () -> this.lifecycleTaskBatchService.updateTaskEventDetails(type, params.get("items")));
   }

--- a/agent/src/main/java/com/cmclinnovations/agent/LifecycleController.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/LifecycleController.java
@@ -838,8 +838,8 @@ public class LifecycleController {
         occurrenceId = id;
         // Search for previous occurrence to retrieve
       } else {
-        occurrenceId = this.lifecycleTaskService.getPreviousOccurrence(id, QueryResource.ID_KEY,
-            orderTypeParams.eventType);
+        occurrenceId = this.lifecycleTaskService.getPreviousOccurrences(List.of(id), QueryResource.ID_KEY,
+            List.of(orderTypeParams.eventType)).get(id);
         // Give blank form template given the missing previous
         if (occurrenceId == null) {
           occurrenceId = "form";

--- a/agent/src/main/java/com/cmclinnovations/agent/LifecycleController.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/LifecycleController.java
@@ -835,7 +835,7 @@ public class LifecycleController {
         // Search for previous occurrence to retrieve
       } else {
         occurrenceId = this.lifecycleTaskService.getPreviousOccurrences(List.of(id), QueryResource.ID_KEY,
-            List.of(orderTypeParams.eventType)).get(id);
+            orderTypeParams.eventType).get(id);
         // Give blank form template given the missing previous
         if (occurrenceId == null) {
           occurrenceId = "form";

--- a/agent/src/main/java/com/cmclinnovations/agent/model/QueryTemplateFactoryParameters.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/model/QueryTemplateFactoryParameters.java
@@ -2,6 +2,7 @@ package com.cmclinnovations.agent.model;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -40,5 +41,10 @@ public record QueryTemplateFactoryParameters(
   public QueryTemplateFactoryParameters(ObjectNode rootNode, String targetId, String branchName,
       Set<String> optVarNames) {
     this(null, rootNode, new ArrayDeque<>(List.of(Arrays.asList(targetId))), null, null, null, branchName, optVarNames);
+  }
+
+  public QueryTemplateFactoryParameters(ObjectNode rootNode, Collection<String> targetIds, String branchName,
+      Set<String> optVarNames) {
+    this(null, rootNode, new ArrayDeque<>(List.of(List.copyOf(targetIds))), null, null, null, branchName, optVarNames);
   }
 }

--- a/agent/src/main/java/com/cmclinnovations/agent/model/type/LifecycleTaskOperationType.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/model/type/LifecycleTaskOperationType.java
@@ -1,5 +1,6 @@
 package com.cmclinnovations.agent.model.type;
 
+import com.cmclinnovations.agent.utils.LifecycleResource;
 import com.cmclinnovations.agent.utils.LocalisationResource;
 
 /**
@@ -10,7 +11,7 @@ public enum LifecycleTaskOperationType {
       "dispatch",
       LifecycleEventType.SERVICE_ORDER_DISPATCHED,
       TrackActionType.ASSIGNMENT,
-      "Order has been assigned and is awaiting execution.",
+      LifecycleResource.ORDER_DISPATCH_MESSAGE,
       null,
       LocalisationResource.SUCCESS_CONTRACT_TASK_ASSIGN_KEY,
       LocalisationResource.SUCCESS_CONTRACT_TASK_BULK_ASSIGN_KEY,

--- a/agent/src/main/java/com/cmclinnovations/agent/model/type/LifecycleTaskOperationType.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/model/type/LifecycleTaskOperationType.java
@@ -100,6 +100,12 @@ public enum LifecycleTaskOperationType {
     return null;
   }
 
+  /**
+   * Groups lifecycle event types for operation configuration.
+   *
+   * @param eventTypes Lifecycle event types to group.
+   * @return Configured lifecycle event types.
+   */
   private static LifecycleEventType[] eventTypes(LifecycleEventType... eventTypes) {
     return eventTypes;
   }

--- a/agent/src/main/java/com/cmclinnovations/agent/model/type/LifecycleTaskOperationType.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/model/type/LifecycleTaskOperationType.java
@@ -1,0 +1,105 @@
+package com.cmclinnovations.agent.model.type;
+
+import com.cmclinnovations.agent.utils.LocalisationResource;
+
+/**
+ * Defines the configuration for supported service task lifecycle operations.
+ */
+public enum LifecycleTaskOperationType {
+  DISPATCH(
+      "dispatch",
+      LifecycleEventType.SERVICE_ORDER_DISPATCHED,
+      TrackActionType.ASSIGNMENT,
+      "Order has been assigned and is awaiting execution.",
+      null,
+      LocalisationResource.SUCCESS_CONTRACT_TASK_ASSIGN_KEY,
+      LocalisationResource.SUCCESS_CONTRACT_TASK_BULK_ASSIGN_KEY,
+      eventTypes(LifecycleEventType.SERVICE_ORDER_RECEIVED),
+      LifecycleEventType.SERVICE_ORDER_RECEIVED);
+
+  private final String id;
+  private final LifecycleEventType eventType;
+  private final TrackActionType trackAction;
+  private final String remarks;
+  private final String eventStatus;
+  private final String successMessageKey;
+  private final String bulkSuccessMessageKey;
+  private final LifecycleEventType[] activityTargetEventTypes;
+  private final LifecycleEventType[] previousEventTypes;
+
+  LifecycleTaskOperationType(String id, LifecycleEventType eventType, TrackActionType trackAction, String remarks,
+      String eventStatus, String successMessageKey, String bulkSuccessMessageKey,
+      LifecycleEventType[] activityTargetEventTypes, LifecycleEventType... previousEventTypes) {
+    this.id = id;
+    this.eventType = eventType;
+    this.trackAction = trackAction;
+    this.remarks = remarks;
+    this.eventStatus = eventStatus;
+    this.successMessageKey = successMessageKey;
+    this.bulkSuccessMessageKey = bulkSuccessMessageKey;
+    this.activityTargetEventTypes = activityTargetEventTypes;
+    this.previousEventTypes = previousEventTypes;
+  }
+
+  public String getId() {
+    return this.id;
+  }
+
+  public LifecycleEventType getEventType() {
+    return this.eventType;
+  }
+
+  public TrackActionType getTrackAction() {
+    return this.trackAction;
+  }
+
+  public String getRemarks() {
+    return this.remarks;
+  }
+
+  public String getEventStatus() {
+    return this.eventStatus;
+  }
+
+  public String getSuccessMessageKey() {
+    return this.successMessageKey;
+  }
+
+  public String getBulkSuccessMessageKey() {
+    return this.bulkSuccessMessageKey;
+  }
+
+  public LifecycleEventType[] getActivityTargetEventTypes() {
+    return this.activityTargetEventTypes.clone();
+  }
+
+  public LifecycleEventType[] getPreviousEventTypes() {
+    return this.previousEventTypes.clone();
+  }
+
+  public boolean supportsBulk() {
+    return this.bulkSuccessMessageKey != null;
+  }
+
+  /**
+   * Retrieves a task operation based on its request identifier.
+   *
+   * @param id Request operation identifier.
+   * @return Matching task operation, or null when unsupported.
+   */
+  public static LifecycleTaskOperationType fromId(String id) {
+    if (id == null) {
+      return null;
+    }
+    for (LifecycleTaskOperationType operation : LifecycleTaskOperationType.values()) {
+      if (operation.getId().equalsIgnoreCase(id)) {
+        return operation;
+      }
+    }
+    return null;
+  }
+
+  private static LifecycleEventType[] eventTypes(LifecycleEventType... eventTypes) {
+    return eventTypes;
+  }
+}

--- a/agent/src/main/java/com/cmclinnovations/agent/service/AddService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/AddService.java
@@ -112,6 +112,51 @@ public class AddService {
   public ResponseEntity<StandardApiResponse<?>> instantiate(String resourceID, String targetId,
       Map<String, Object> param, String successLogMessage, String messageResource, TrackActionType trackAction) {
     LOGGER.info("Instantiating an instance of {} ...", resourceID);
+    ObjectNode addJsonSchema = this.renderJsonLd(resourceID, targetId, param);
+    return this.instantiateJsonLd(addJsonSchema, resourceID, successLogMessage, messageResource, trackAction);
+  }
+
+  /**
+   * Instantiates multiple instances in one JSON-LD addition.
+   *
+   * @param paramsByResourceId Request parameters grouped by resource identifier.
+   */
+  public ResponseEntity<StandardApiResponse<?>> instantiateBatch(
+      Map<String, List<Map<String, Object>>> paramsByResourceId) {
+    if (paramsByResourceId == null || paramsByResourceId.isEmpty()
+        || paramsByResourceId.entrySet().stream().anyMatch(entry -> entry.getKey() == null
+            || entry.getKey().isBlank() || entry.getValue() == null || entry.getValue().isEmpty()
+            || entry.getValue().stream().anyMatch(java.util.Objects::isNull))) {
+      throw new IllegalArgumentException("At least one valid instantiation entry is required!");
+    }
+
+    ArrayNode batchJsonLd = this.jsonLdService.genArrayNode();
+    List<String> resourceIds = new ArrayList<>();
+    List<ObjectNode> jsonLdSchemas = new ArrayList<>();
+    List<String> instanceIris = new ArrayList<>();
+    paramsByResourceId.forEach((resourceID, params) -> params.forEach(param -> {
+      String targetId = param.getOrDefault(QueryResource.ID_KEY, UUID.randomUUID()).toString();
+      ObjectNode jsonLdSchema = this.renderJsonLd(resourceID, targetId, param);
+      batchJsonLd.add(jsonLdSchema);
+      resourceIds.add(resourceID);
+      jsonLdSchemas.add(jsonLdSchema);
+      instanceIris.add(jsonLdSchema.path(ShaclResource.ID_KEY).asString());
+    }));
+
+    LOGGER.info("Adding {} instances to endpoint...", instanceIris.size());
+    ResponseEntity<String> response = this.kgService.add(batchJsonLd.toString());
+    if (response.getStatusCode() != HttpStatus.OK) {
+      LOGGER.warn(response.getBody());
+      throw new IllegalStateException(LocalisationTranslator.getMessage(LocalisationResource.ERROR_ADD_KEY));
+    }
+
+    for (int index = 0; index < jsonLdSchemas.size(); index++) {
+      this.execShaclRules(resourceIds.get(index), instanceIris.get(index), jsonLdSchemas.get(index).toString());
+    }
+    return this.responseEntityBuilder.success(instanceIris);
+  }
+
+  private ObjectNode renderJsonLd(String resourceID, String targetId, Map<String, Object> param) {
     // Update ID value to target ID
     param.put(QueryResource.ID_KEY, targetId);
     // Retrieve the instantiation JSON schema
@@ -121,7 +166,7 @@ public class AddService {
     this.recursiveReplacePlaceholders(addJsonSchema, null, null, param);
     // Add the static ID reference
     this.jsonLdService.appendId(addJsonSchema, targetId);
-    return this.instantiateJsonLd(addJsonSchema, resourceID, successLogMessage, messageResource, trackAction);
+    return addJsonSchema;
   }
 
   /**
@@ -177,6 +222,18 @@ public class AddService {
       LOGGER.warn(response.getBody());
       throw new IllegalStateException(LocalisationTranslator.getMessage(LocalisationResource.ERROR_ADD_KEY));
     }
+    this.execShaclRules(resourceID, instanceIri, jsonString);
+
+    LOGGER.info(successLogMessage == null ? "Instantiation is successful!" : successLogMessage);
+    if (trackAction != TrackActionType.IGNORED) {
+      this.logActivity(instanceIri, trackAction);
+    }
+    return this.responseEntityBuilder.success(instanceIri,
+        LocalisationTranslator
+            .getMessage(messageResource == null ? LocalisationResource.SUCCESS_ADD_KEY : messageResource));
+  }
+
+  private void execShaclRules(String resourceID, String instanceIri, String jsonString) {
     this.execSparqlConstructRules(resourceID, instanceIri);
 
     Model otherRules = this.kgService.getShaclRules(resourceID, ShaclRuleType.TRIPLE_RULE);
@@ -191,19 +248,11 @@ public class AddService {
             .format(RDFFormat.JSONLD)
             .output(out);
         String stringifiedInferredData = out.toString(StandardCharsets.UTF_8);
-        response = this.kgService.add(stringifiedInferredData);
+        this.kgService.add(stringifiedInferredData);
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }
     }
-
-    LOGGER.info(successLogMessage == null ? "Instantiation is successful!" : successLogMessage);
-    if (trackAction != TrackActionType.IGNORED) {
-      this.logActivity(instanceIri, trackAction);
-    }
-    return this.responseEntityBuilder.success(instanceIri,
-        LocalisationTranslator
-            .getMessage(messageResource == null ? LocalisationResource.SUCCESS_ADD_KEY : messageResource));
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/service/AddService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/AddService.java
@@ -118,6 +118,7 @@ public class AddService {
 
   /**
    * Instantiates multiple instances in one JSON-LD addition.
+   * Activity logging is not included here and must be handled by the caller.
    *
    * @param paramsByResourceId Request parameters grouped by resource identifier.
    */
@@ -130,6 +131,7 @@ public class AddService {
       throw new IllegalArgumentException("At least one valid instantiation entry is required!");
     }
 
+    // Render every entry before submitting one combined JSON-LD payload.
     ArrayNode batchJsonLd = this.jsonLdService.genArrayNode();
     List<String> resourceIds = new ArrayList<>();
     List<ObjectNode> jsonLdSchemas = new ArrayList<>();
@@ -150,6 +152,7 @@ public class AddService {
       throw new IllegalStateException(LocalisationTranslator.getMessage(LocalisationResource.ERROR_ADD_KEY));
     }
 
+    // Preserve per-instance SHACL processing after the combined write succeeds.
     for (int index = 0; index < jsonLdSchemas.size(); index++) {
       this.execShaclRules(resourceIds.get(index), instanceIris.get(index), jsonLdSchemas.get(index).toString());
     }

--- a/agent/src/main/java/com/cmclinnovations/agent/service/AddService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/AddService.java
@@ -157,6 +157,14 @@ public class AddService {
     return this.responseEntityBuilder.success(instanceIris);
   }
 
+  /**
+   * Renders a JSON-LD instance from the resource template and input parameters.
+   *
+   * @param resourceID The target resource identifier for the instance.
+   * @param targetId   The target instance identifier.
+   * @param param      Request parameters used to populate the template.
+   * @return Rendered JSON-LD instance.
+   */
   private ObjectNode renderJsonLd(String resourceID, String targetId, Map<String, Object> param) {
     // Update ID value to target ID
     param.put(QueryResource.ID_KEY, targetId);

--- a/agent/src/main/java/com/cmclinnovations/agent/service/AddService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/AddService.java
@@ -123,11 +123,8 @@ public class AddService {
    * @param paramsByResourceId Request parameters grouped by resource identifier.
    */
   public ResponseEntity<StandardApiResponse<?>> instantiateBatch(
-      Map<String, List<Map<String, Object>>> paramsByResourceId) {
-    if (paramsByResourceId == null || paramsByResourceId.isEmpty()
-        || paramsByResourceId.entrySet().stream().anyMatch(entry -> entry.getKey() == null
-            || entry.getKey().isBlank() || entry.getValue() == null || entry.getValue().isEmpty()
-            || entry.getValue().stream().anyMatch(java.util.Objects::isNull))) {
+      String resourceID, List<Map<String, Object>> params) {
+    if (params == null || params.isEmpty()) {
       throw new IllegalArgumentException("At least one valid instantiation entry is required!");
     }
 
@@ -136,14 +133,14 @@ public class AddService {
     List<String> resourceIds = new ArrayList<>();
     List<ObjectNode> jsonLdSchemas = new ArrayList<>();
     List<String> instanceIris = new ArrayList<>();
-    paramsByResourceId.forEach((resourceID, params) -> params.forEach(param -> {
+    params.forEach(param -> {
       String targetId = param.getOrDefault(QueryResource.ID_KEY, UUID.randomUUID()).toString();
       ObjectNode jsonLdSchema = this.renderJsonLd(resourceID, targetId, param);
       batchJsonLd.add(jsonLdSchema);
       resourceIds.add(resourceID);
       jsonLdSchemas.add(jsonLdSchema);
       instanceIris.add(jsonLdSchema.path(ShaclResource.ID_KEY).asString());
-    }));
+    });
 
     LOGGER.info("Adding {} instances to endpoint...", instanceIris.size());
     ResponseEntity<String> response = this.kgService.add(batchJsonLd.toString());

--- a/agent/src/main/java/com/cmclinnovations/agent/service/AddService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/AddService.java
@@ -120,8 +120,8 @@ public class AddService {
    * Instantiates multiple instances in one JSON-LD addition.
    * Activity logging is not included here and must be handled by the caller.
    *
-   * @param resourceID  The target resource identifier for the instance.
-   * @param param       Request parameters.
+   * @param resourceID The target resource identifier for the instance.
+   * @param params     Request parameters.
    */
   public ResponseEntity<StandardApiResponse<?>> instantiateBatch(
       String resourceID, List<Map<String, Object>> params) {
@@ -242,6 +242,13 @@ public class AddService {
             .getMessage(messageResource == null ? LocalisationResource.SUCCESS_ADD_KEY : messageResource));
   }
 
+  /**
+   * Executes SHACL rules for a newly instantiated JSON-LD instance.
+   *
+   * @param resourceID The target resource identifier for the instance.
+   * @param instanceIri The instantiated resource IRI.
+   * @param jsonString  The instantiated JSON-LD content.
+   */
   private void execShaclRules(String resourceID, String instanceIri, String jsonString) {
     this.execSparqlConstructRules(resourceID, instanceIri);
 

--- a/agent/src/main/java/com/cmclinnovations/agent/service/AddService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/AddService.java
@@ -120,7 +120,8 @@ public class AddService {
    * Instantiates multiple instances in one JSON-LD addition.
    * Activity logging is not included here and must be handled by the caller.
    *
-   * @param paramsByResourceId Request parameters grouped by resource identifier.
+   * @param resourceID  The target resource identifier for the instance.
+   * @param param       Request parameters.
    */
   public ResponseEntity<StandardApiResponse<?>> instantiateBatch(
       String resourceID, List<Map<String, Object>> params) {

--- a/agent/src/main/java/com/cmclinnovations/agent/service/DeleteService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/DeleteService.java
@@ -1,5 +1,6 @@
 package com.cmclinnovations.agent.service;
 
+import java.util.Collection;
 import java.util.Queue;
 import java.util.Set;
 
@@ -58,20 +59,20 @@ public class DeleteService {
   }
 
   /**
-   * Delete a lifecycle occurrence associated with the target identifier and event
-   * type.
+   * Delete lifecycle occurrences associated with the target identifiers and
+   * event type in one operation.
    *
-   * @param resourceID The target resource identifier for the instance.
-   * @param targetId   The target instance identifier.
+   * @param resourceID The target resource identifier for the instances.
+   * @param targetIds  The target instance identifiers.
    * @param eventType  The lifecycle event type to delete.
    */
-  public ResponseEntity<StandardApiResponse<?>> deleteLifecycleOccurrence(String resourceID, String targetId,
-      LifecycleEventType eventType) {
-    LOGGER.debug("Deleting {} lifecycle occurrence of {}", resourceID, targetId);
+  public ResponseEntity<StandardApiResponse<?>> deleteLifecycleOccurrences(String resourceID,
+      Collection<String> targetIds, LifecycleEventType eventType) {
+    LOGGER.debug("Deleting {} lifecycle occurrences", resourceID);
     Set<String> optVarNames = this.kgService.getSparqlOptionalParameters(resourceID);
-    String query = this.queryTemplateService.genDeleteLifecycleOccurrenceQuery(
-        resourceID, targetId, null, optVarNames, eventType.getEvent());
-    return this.kgService.delete(query, targetId);
+    String query = this.queryTemplateService.genDeleteLifecycleOccurrencesQuery(
+        resourceID, targetIds, null, optVarNames, eventType.getEvent());
+    return this.kgService.delete(query, targetIds.iterator().next());
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/service/DeleteService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/DeleteService.java
@@ -55,7 +55,7 @@ public class DeleteService {
     Set<String> optVarNames = this.kgService.getSparqlOptionalParameters(resourceID);
     // Generate query with branch validation
     String query = this.queryTemplateService.genDeleteQuery(resourceID, targetId, branchName, optVarNames);
-    return this.kgService.delete(query, targetId);
+    return this.kgService.delete(query);
   }
 
   /**
@@ -72,7 +72,7 @@ public class DeleteService {
     Set<String> optVarNames = this.kgService.getSparqlOptionalParameters(resourceID);
     String query = this.queryTemplateService.genDeleteLifecycleOccurrencesQuery(
         resourceID, targetIds, null, optVarNames, eventType.getEvent());
-    return this.kgService.delete(query, targetIds.iterator().next());
+    return this.kgService.delete(query);
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/service/DeleteService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/DeleteService.java
@@ -1,6 +1,5 @@
 package com.cmclinnovations.agent.service;
 
-import java.util.Collection;
 import java.util.Queue;
 import java.util.Set;
 
@@ -67,10 +66,10 @@ public class DeleteService {
    * @param eventType  The lifecycle event type to delete.
    */
   public ResponseEntity<StandardApiResponse<?>> deleteLifecycleOccurrences(String resourceID,
-      Collection<String> targetIds, LifecycleEventType eventType) {
+      Set<String> targetIds, LifecycleEventType eventType) {
     LOGGER.debug("Deleting {} lifecycle occurrences", resourceID);
     Set<String> optVarNames = this.kgService.getSparqlOptionalParameters(resourceID);
-    String query = this.queryTemplateService.genDeleteLifecycleOccurrencesQuery(
+    String query = this.queryTemplateService.genDeleteLifecycleOccurrencesBatchQuery(
         resourceID, targetIds, null, optVarNames, eventType.getEvent());
     return this.kgService.delete(query);
   }

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
@@ -132,7 +132,7 @@ public class LifecycleTaskBatchService {
   }
 
   /**
-   * Validates task inputs and returns their unique identifiers in request order.
+   * Validates task inputs and returns their unique identifiers.
    *
    * @param items Task details to validate.
    * @return Validated task identifiers.

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
@@ -1,0 +1,177 @@
+package com.cmclinnovations.agent.service.application;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.cmclinnovations.agent.component.LocalisationTranslator;
+import com.cmclinnovations.agent.component.ResponseEntityBuilder;
+import com.cmclinnovations.agent.model.response.StandardApiResponse;
+import com.cmclinnovations.agent.model.type.LifecycleEventType;
+import com.cmclinnovations.agent.model.type.TrackActionType;
+import com.cmclinnovations.agent.service.AddService;
+import com.cmclinnovations.agent.service.DeleteService;
+import com.cmclinnovations.agent.service.core.DateTimeService;
+import com.cmclinnovations.agent.service.core.FileService;
+import com.cmclinnovations.agent.utils.LifecycleResource;
+import com.cmclinnovations.agent.utils.LocalisationResource;
+import com.cmclinnovations.agent.utils.QueryResource;
+
+@Service
+public class LifecycleTaskBatchService {
+  private final AddService addService;
+  private final DateTimeService dateTimeService;
+  private final DeleteService deleteService;
+  private final LifecycleQueryService lifecycleQueryService;
+  private final LifecycleTaskService lifecycleTaskService;
+  private final ResponseEntityBuilder responseEntityBuilder;
+
+  private static final String ORDER_DISPATCH_MESSAGE = "Order has been assigned and is awaiting execution.";
+
+  public LifecycleTaskBatchService(AddService addService, DateTimeService dateTimeService, DeleteService deleteService,
+      LifecycleQueryService lifecycleQueryService, LifecycleTaskService lifecycleTaskService,
+      ResponseEntityBuilder responseEntityBuilder) {
+    this.addService = addService;
+    this.dateTimeService = dateTimeService;
+    this.deleteService = deleteService;
+    this.lifecycleQueryService = lifecycleQueryService;
+    this.lifecycleTaskService = lifecycleTaskService;
+    this.responseEntityBuilder = responseEntityBuilder;
+  }
+
+  /**
+   * Updates lifecycle event details for multiple tasks in one delete and add.
+   */
+  public ResponseEntity<StandardApiResponse<?>> updateTaskEventDetails(String type,
+      List<Map<String, Object>> items) {
+    BatchEventConfig config = this.getConfig(type);
+    List<String> taskIds = this.validateAndGetTaskIds(items);
+
+    Map<String, String> previousOccurrences = this.lifecycleTaskService.getPreviousOccurrences(
+        taskIds, QueryResource.IRI_KEY, config.previousEventTypes());
+    this.requirePreviousOccurrences(taskIds, previousOccurrences);
+
+    Map<String, String> activityTargets = config.activityTargetEventTypes().equals(config.previousEventTypes())
+        ? previousOccurrences
+        : this.lifecycleTaskService.getPreviousOccurrences(
+            taskIds, QueryResource.IRI_KEY, config.activityTargetEventTypes());
+    this.requirePreviousOccurrences(taskIds, activityTargets);
+
+    this.prepareItems(items, previousOccurrences, config);
+
+    ResponseEntity<StandardApiResponse<?>> response = this.deleteService.deleteLifecycleOccurrences(
+        config.eventType().getId(), taskIds, config.eventType());
+    if (response.getStatusCode() != HttpStatus.OK) {
+      return response;
+    }
+
+    response = this.addService.instantiateBatch(Map.of(config.eventType().getId(), items));
+    if (response.getStatusCode() != HttpStatus.OK) {
+      return response;
+    }
+
+    taskIds.forEach(taskId -> this.addService.logActivity(activityTargets.get(taskId), config.trackAction()));
+    return this.responseEntityBuilder.success("task",
+        LocalisationTranslator.getMessage(config.successMessageKey()));
+  }
+
+  private BatchEventConfig getConfig(String type) {
+    if (type == null) {
+      throw new IllegalArgumentException(
+          LocalisationTranslator.getMessage(LocalisationResource.ERROR_INVALID_EVENT_TYPE_KEY));
+    }
+    return switch (type.toLowerCase(Locale.ROOT)) {
+      case "dispatch" -> new BatchEventConfig(
+          LifecycleEventType.SERVICE_ORDER_DISPATCHED,
+          List.of(LifecycleEventType.SERVICE_ORDER_RECEIVED),
+          List.of(LifecycleEventType.SERVICE_ORDER_RECEIVED),
+          TrackActionType.ASSIGNMENT,
+          ORDER_DISPATCH_MESSAGE,
+          null,
+          LocalisationResource.SUCCESS_CONTRACT_TASK_BULK_ASSIGN_KEY);
+      default -> throw new IllegalArgumentException(
+          LocalisationTranslator.getMessage(LocalisationResource.ERROR_INVALID_EVENT_TYPE_KEY));
+    };
+  }
+
+  private List<String> validateAndGetTaskIds(List<Map<String, Object>> items) {
+    if (items == null) {
+      throw new IllegalArgumentException(
+          LocalisationTranslator.getMessage(LocalisationResource.ERROR_MISSING_FIELD_KEY, "items"));
+    }
+    if (items.isEmpty()) {
+      throw new IllegalArgumentException("At least one task is required!");
+    }
+
+    List<String> taskIds = new ArrayList<>();
+    Set<String> uniqueTaskIds = new HashSet<>();
+    for (Map<String, Object> item : items) {
+      if (item == null) {
+        throw new IllegalArgumentException("Task details cannot be null!");
+      }
+      String taskId = this.getRequiredValue(item, QueryResource.ID_KEY);
+      this.getRequiredValue(item, LifecycleResource.CONTRACT_KEY);
+      if (!uniqueTaskIds.add(taskId)) {
+        throw new IllegalArgumentException("Duplicate task identifier: " + taskId);
+      }
+      taskIds.add(taskId);
+    }
+    return taskIds;
+  }
+
+  private String getRequiredValue(Map<String, Object> item, String field) {
+    Object value = item.get(field);
+    if (value == null || value.toString().isBlank()) {
+      throw new IllegalArgumentException(
+          LocalisationTranslator.getMessage(LocalisationResource.ERROR_MISSING_FIELD_KEY, field));
+    }
+    return value.toString();
+  }
+
+  private void requirePreviousOccurrences(List<String> taskIds, Map<String, String> previousOccurrences) {
+    List<String> missingTaskIds = taskIds.stream()
+        .filter(taskId -> !previousOccurrences.containsKey(taskId))
+        .toList();
+    if (!missingTaskIds.isEmpty()) {
+      throw new NullPointerException(
+          "No valid previous occurrence found for task identifiers: " + String.join(", ", missingTaskIds));
+    }
+  }
+
+  private void prepareItems(List<Map<String, Object>> items, Map<String, String> previousOccurrences,
+      BatchEventConfig config) {
+    Map<String, String> stagesByContract = new HashMap<>();
+    for (Map<String, Object> item : items) {
+      String contractId = item.get(LifecycleResource.CONTRACT_KEY).toString();
+      String stage = stagesByContract.computeIfAbsent(contractId,
+          id -> this.lifecycleQueryService.getInstance(FileService.CONTRACT_STAGE_QUERY_RESOURCE, id,
+              config.eventType().getStage()).getFieldValue(QueryResource.IRI_KEY));
+
+      item.put(LifecycleResource.DATE_TIME_KEY, this.dateTimeService.getCurrentDateTime());
+      item.put(LifecycleResource.STAGE_KEY, stage);
+      item.put(LifecycleResource.REMARKS_KEY, config.remarks());
+      item.put(LifecycleResource.ORDER_KEY, previousOccurrences.get(item.get(QueryResource.ID_KEY).toString()));
+      if (config.eventStatus() != null) {
+        item.put(LifecycleResource.EVENT_STATUS_KEY, config.eventStatus());
+      }
+    }
+  }
+
+  private record BatchEventConfig(
+      LifecycleEventType eventType,
+      List<LifecycleEventType> previousEventTypes,
+      List<LifecycleEventType> activityTargetEventTypes,
+      TrackActionType trackAction,
+      String remarks,
+      String eventStatus,
+      String successMessageKey) {
+  }
+}

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
@@ -83,7 +83,7 @@ public class LifecycleTaskBatchService {
       return response;
     }
 
-    response = this.addService.instantiateBatch(Map.of(config.getEventType().getId(), items));
+    response = this.addService.instantiateBatch(config.getEventType().getId(), items);
     if (response.getStatusCode() != HttpStatus.OK) {
       return response;
     }
@@ -93,7 +93,7 @@ public class LifecycleTaskBatchService {
     List<String> activityTargetIris = taskIds.stream().map(activityTargets::get).toList();
     List<Map<String, Object>> activityParams = this.changelogService.prepareActivities(
         activityTargetIris, config.getTrackAction(), agentIri);
-    response = this.addService.instantiateBatch(Map.of(QueryResource.HISTORY_ACTIVITY_RESOURCE, activityParams));
+    response = this.addService.instantiateBatch(QueryResource.HISTORY_ACTIVITY_RESOURCE, activityParams);
     if (response.getStatusCode() != HttpStatus.OK) {
       return response;
     }

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
@@ -1,6 +1,7 @@
 package com.cmclinnovations.agent.service.application;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -64,7 +65,8 @@ public class LifecycleTaskBatchService {
     this.requirePreviousOccurrences(taskIds, previousOccurrences);
 
     // Reuse predecessor results when activity history targets the same event type.
-    Map<String, String> activityTargets = config.activityTargetEventTypes().equals(config.previousEventTypes())
+    Map<String, String> activityTargets = Arrays.equals(
+        config.activityTargetEventTypes(), config.previousEventTypes())
         ? previousOccurrences
         : this.lifecycleTaskService.getPreviousOccurrences(
             taskIds, QueryResource.IRI_KEY, config.activityTargetEventTypes());
@@ -115,8 +117,8 @@ public class LifecycleTaskBatchService {
     return switch (type.toLowerCase(Locale.ROOT)) {
       case "dispatch" -> new BatchEventConfig(
           LifecycleEventType.SERVICE_ORDER_DISPATCHED,
-          List.of(LifecycleEventType.SERVICE_ORDER_RECEIVED),
-          List.of(LifecycleEventType.SERVICE_ORDER_RECEIVED),
+          new LifecycleEventType[] { LifecycleEventType.SERVICE_ORDER_RECEIVED },
+          new LifecycleEventType[] { LifecycleEventType.SERVICE_ORDER_RECEIVED },
           TrackActionType.ASSIGNMENT,
           ORDER_DISPATCH_MESSAGE,
           null,
@@ -193,8 +195,8 @@ public class LifecycleTaskBatchService {
 
   private record BatchEventConfig(
       LifecycleEventType eventType,
-      List<LifecycleEventType> previousEventTypes,
-      List<LifecycleEventType> activityTargetEventTypes,
+      LifecycleEventType[] previousEventTypes,
+      LifecycleEventType[] activityTargetEventTypes,
       TrackActionType trackAction,
       String remarks,
       String eventStatus,

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
@@ -91,7 +91,7 @@ public class LifecycleTaskBatchService {
     // Log only after every dispatch and its SHACL processing has succeeded.
     String agentIri = this.instantiateAgent();
     List<String> activityTargetIris = taskIds.stream().map(activityTargets::get).toList();
-    List<Map<String, Object>> activityParams = this.changelogService.prepareActivities(
+    List<Map<String, Object>> activityParams = this.changelogService.logActions(
         activityTargetIris, config.getTrackAction(), agentIri);
     response = this.addService.instantiateBatch(QueryResource.HISTORY_ACTIVITY_RESOURCE, activityParams);
     if (response.getStatusCode() != HttpStatus.OK) {

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
@@ -1,6 +1,5 @@
 package com.cmclinnovations.agent.service.application;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -60,7 +59,7 @@ public class LifecycleTaskBatchService {
   public ResponseEntity<StandardApiResponse<?>> updateTaskEventDetails(String type,
       List<Map<String, Object>> items) {
     LifecycleTaskOperationType config = this.getConfig(type);
-    List<String> taskIds = this.validateAndGetTaskIds(items);
+    Set<String> taskIds = this.validateAndGetTaskIds(items);
     LifecycleEventType[] previousEventTypes = config.getPreviousEventTypes();
 
     Map<String, String> previousOccurrences = this.lifecycleTaskService.getPreviousOccurrences(
@@ -138,7 +137,7 @@ public class LifecycleTaskBatchService {
    * @param items Task details to validate.
    * @return Validated task identifiers.
    */
-  private List<String> validateAndGetTaskIds(List<Map<String, Object>> items) {
+  private Set<String> validateAndGetTaskIds(List<Map<String, Object>> items) {
     if (items == null) {
       throw new IllegalArgumentException(
           LocalisationTranslator.getMessage(LocalisationResource.ERROR_MISSING_FIELD_KEY, "items"));
@@ -147,8 +146,7 @@ public class LifecycleTaskBatchService {
       throw new IllegalArgumentException("At least one task is required!");
     }
 
-    List<String> taskIds = new ArrayList<>();
-    Set<String> uniqueTaskIds = new HashSet<>();
+    Set<String> taskIds = new HashSet<>();
     for (Map<String, Object> item : items) {
       if (item == null) {
         throw new IllegalArgumentException("Task details cannot be null!");
@@ -156,10 +154,9 @@ public class LifecycleTaskBatchService {
       String taskId = this.getRequiredValue(item, QueryResource.ID_KEY);
       this.getRequiredValue(item, LifecycleResource.CONTRACT_KEY);
       // Reject duplicate tasks before any lifecycle mutation occurs.
-      if (!uniqueTaskIds.add(taskId)) {
+      if (!taskIds.add(taskId)) {
         throw new IllegalArgumentException("Duplicate task identifier: " + taskId);
       }
-      taskIds.add(taskId);
     }
     return taskIds;
   }
@@ -186,7 +183,7 @@ public class LifecycleTaskBatchService {
    * @param taskIds            Requested task identifiers.
    * @param previousOccurrences Previous occurrences indexed by task identifier.
    */
-  private void requirePreviousOccurrences(List<String> taskIds, Map<String, String> previousOccurrences) {
+  private void requirePreviousOccurrences(Set<String> taskIds, Map<String, String> previousOccurrences) {
     List<String> missingTaskIds = taskIds.stream()
         .filter(taskId -> !previousOccurrences.containsKey(taskId))
         .toList();

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
@@ -63,6 +63,7 @@ public class LifecycleTaskBatchService {
         taskIds, QueryResource.IRI_KEY, config.previousEventTypes());
     this.requirePreviousOccurrences(taskIds, previousOccurrences);
 
+    // Reuse predecessor results when activity history targets the same event type.
     Map<String, String> activityTargets = config.activityTargetEventTypes().equals(config.previousEventTypes())
         ? previousOccurrences
         : this.lifecycleTaskService.getPreviousOccurrences(
@@ -82,6 +83,7 @@ public class LifecycleTaskBatchService {
       return response;
     }
 
+    // Log only after every dispatch and its SHACL processing has succeeded.
     String agentIri = this.instantiateAgent();
     List<String> activityTargetIris = taskIds.stream().map(activityTargets::get).toList();
     List<Map<String, Object>> activityParams = this.changelogService.prepareActivities(
@@ -97,6 +99,7 @@ public class LifecycleTaskBatchService {
 
   private String instantiateAgent() {
     Map<String, Object> agentParams = this.changelogService.setAgent();
+    // Authentication-disabled requests do not create or reference an agent.
     if (agentParams.isEmpty()) {
       return null;
     }
@@ -140,6 +143,7 @@ public class LifecycleTaskBatchService {
       }
       String taskId = this.getRequiredValue(item, QueryResource.ID_KEY);
       this.getRequiredValue(item, LifecycleResource.CONTRACT_KEY);
+      // Reject duplicate tasks before any lifecycle mutation occurs.
       if (!uniqueTaskIds.add(taskId)) {
         throw new IllegalArgumentException("Duplicate task identifier: " + taskId);
       }
@@ -169,6 +173,7 @@ public class LifecycleTaskBatchService {
 
   private void prepareItems(List<Map<String, Object>> items, Map<String, String> previousOccurrences,
       BatchEventConfig config) {
+    // Reuse the stage IRI for tasks belonging to the same contract.
     Map<String, String> stagesByContract = new HashMap<>();
     for (Map<String, Object> item : items) {
       String contractId = item.get(LifecycleResource.CONTRACT_KEY).toString();

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
@@ -19,6 +19,7 @@ import com.cmclinnovations.agent.model.type.LifecycleEventType;
 import com.cmclinnovations.agent.model.type.TrackActionType;
 import com.cmclinnovations.agent.service.AddService;
 import com.cmclinnovations.agent.service.DeleteService;
+import com.cmclinnovations.agent.service.core.ChangelogService;
 import com.cmclinnovations.agent.service.core.DateTimeService;
 import com.cmclinnovations.agent.service.core.FileService;
 import com.cmclinnovations.agent.utils.LifecycleResource;
@@ -28,6 +29,7 @@ import com.cmclinnovations.agent.utils.QueryResource;
 @Service
 public class LifecycleTaskBatchService {
   private final AddService addService;
+  private final ChangelogService changelogService;
   private final DateTimeService dateTimeService;
   private final DeleteService deleteService;
   private final LifecycleQueryService lifecycleQueryService;
@@ -36,10 +38,11 @@ public class LifecycleTaskBatchService {
 
   private static final String ORDER_DISPATCH_MESSAGE = "Order has been assigned and is awaiting execution.";
 
-  public LifecycleTaskBatchService(AddService addService, DateTimeService dateTimeService, DeleteService deleteService,
-      LifecycleQueryService lifecycleQueryService, LifecycleTaskService lifecycleTaskService,
-      ResponseEntityBuilder responseEntityBuilder) {
+  public LifecycleTaskBatchService(AddService addService, ChangelogService changelogService,
+      DateTimeService dateTimeService, DeleteService deleteService, LifecycleQueryService lifecycleQueryService,
+      LifecycleTaskService lifecycleTaskService, ResponseEntityBuilder responseEntityBuilder) {
     this.addService = addService;
+    this.changelogService = changelogService;
     this.dateTimeService = dateTimeService;
     this.deleteService = deleteService;
     this.lifecycleQueryService = lifecycleQueryService;
@@ -48,7 +51,8 @@ public class LifecycleTaskBatchService {
   }
 
   /**
-   * Updates lifecycle event details for multiple tasks in one delete and add.
+   * Updates lifecycle event details for multiple tasks, then logs their
+   * activities in a separate batch.
    */
   public ResponseEntity<StandardApiResponse<?>> updateTaskEventDetails(String type,
       List<Map<String, Object>> items) {
@@ -78,9 +82,26 @@ public class LifecycleTaskBatchService {
       return response;
     }
 
-    taskIds.forEach(taskId -> this.addService.logActivity(activityTargets.get(taskId), config.trackAction()));
+    String agentIri = this.instantiateAgent();
+    List<String> activityTargetIris = taskIds.stream().map(activityTargets::get).toList();
+    List<Map<String, Object>> activityParams = this.changelogService.prepareActivities(
+        activityTargetIris, config.trackAction(), agentIri);
+    response = this.addService.instantiateBatch(Map.of(QueryResource.HISTORY_ACTIVITY_RESOURCE, activityParams));
+    if (response.getStatusCode() != HttpStatus.OK) {
+      return response;
+    }
+
     return this.responseEntityBuilder.success("task",
         LocalisationTranslator.getMessage(config.successMessageKey()));
+  }
+
+  private String instantiateAgent() {
+    Map<String, Object> agentParams = this.changelogService.setAgent();
+    if (agentParams.isEmpty()) {
+      return null;
+    }
+    return this.addService.instantiate(
+        QueryResource.HISTORY_AGENT_RESOURCE, agentParams, TrackActionType.IGNORED).getBody().data().id();
   }
 
   private BatchEventConfig getConfig(String type) {

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
@@ -54,6 +54,10 @@ public class LifecycleTaskBatchService {
   /**
    * Updates lifecycle event details for multiple tasks, then logs their
    * activities in a separate batch.
+   *
+   * @param type  Lifecycle operation type.
+   * @param items Task details to update.
+   * @return Response describing the batch operation outcome.
    */
   public ResponseEntity<StandardApiResponse<?>> updateTaskEventDetails(String type,
       List<Map<String, Object>> items) {
@@ -99,6 +103,11 @@ public class LifecycleTaskBatchService {
         LocalisationTranslator.getMessage(config.successMessageKey()));
   }
 
+  /**
+   * Creates the authenticated agent when authentication is enabled.
+   *
+   * @return Instantiated agent IRI, or null when authentication is disabled.
+   */
   private String instantiateAgent() {
     Map<String, Object> agentParams = this.changelogService.setAgent();
     // Authentication-disabled requests do not create or reference an agent.
@@ -109,6 +118,12 @@ public class LifecycleTaskBatchService {
         QueryResource.HISTORY_AGENT_RESOURCE, agentParams, TrackActionType.IGNORED).getBody().data().id();
   }
 
+  /**
+   * Retrieves the processing configuration for a supported lifecycle operation.
+   *
+   * @param type Lifecycle operation type.
+   * @return Configuration for processing the requested operation.
+   */
   private BatchEventConfig getConfig(String type) {
     if (type == null) {
       throw new IllegalArgumentException(
@@ -128,6 +143,12 @@ public class LifecycleTaskBatchService {
     };
   }
 
+  /**
+   * Validates task inputs and returns their unique identifiers in request order.
+   *
+   * @param items Task details to validate.
+   * @return Validated task identifiers.
+   */
   private List<String> validateAndGetTaskIds(List<Map<String, Object>> items) {
     if (items == null) {
       throw new IllegalArgumentException(
@@ -154,6 +175,13 @@ public class LifecycleTaskBatchService {
     return taskIds;
   }
 
+  /**
+   * Retrieves a required non-blank value from a task input.
+   *
+   * @param item  Task details containing the value.
+   * @param field Required field name.
+   * @return Required value as a string.
+   */
   private String getRequiredValue(Map<String, Object> item, String field) {
     Object value = item.get(field);
     if (value == null || value.toString().isBlank()) {
@@ -163,6 +191,12 @@ public class LifecycleTaskBatchService {
     return value.toString();
   }
 
+  /**
+   * Verifies that every requested task has a matching previous occurrence.
+   *
+   * @param taskIds            Requested task identifiers.
+   * @param previousOccurrences Previous occurrences indexed by task identifier.
+   */
   private void requirePreviousOccurrences(List<String> taskIds, Map<String, String> previousOccurrences) {
     List<String> missingTaskIds = taskIds.stream()
         .filter(taskId -> !previousOccurrences.containsKey(taskId))
@@ -173,6 +207,13 @@ public class LifecycleTaskBatchService {
     }
   }
 
+  /**
+   * Adds generated lifecycle values to every task before batch instantiation.
+   *
+   * @param items               Task details to prepare.
+   * @param previousOccurrences Previous occurrences indexed by task identifier.
+   * @param config              Lifecycle operation configuration.
+   */
   private void prepareItems(List<Map<String, Object>> items, Map<String, String> previousOccurrences,
       BatchEventConfig config) {
     // Reuse the stage IRI for tasks belonging to the same contract.
@@ -193,6 +234,17 @@ public class LifecycleTaskBatchService {
     }
   }
 
+  /**
+   * Configuration required to process one supported batch lifecycle event.
+   *
+   * @param eventType                Lifecycle event to create.
+   * @param previousEventTypes       Allowed predecessor events in fallback order.
+   * @param activityTargetEventTypes Events targeted by the resulting activities.
+   * @param trackAction              Activity action to record.
+   * @param remarks                  Remarks assigned to each lifecycle event.
+   * @param eventStatus              Optional status assigned to each event.
+   * @param successMessageKey        Localised success message key.
+   */
   private record BatchEventConfig(
       LifecycleEventType eventType,
       LifecycleEventType[] previousEventTypes,

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskBatchService.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -17,6 +16,7 @@ import com.cmclinnovations.agent.component.LocalisationTranslator;
 import com.cmclinnovations.agent.component.ResponseEntityBuilder;
 import com.cmclinnovations.agent.model.response.StandardApiResponse;
 import com.cmclinnovations.agent.model.type.LifecycleEventType;
+import com.cmclinnovations.agent.model.type.LifecycleTaskOperationType;
 import com.cmclinnovations.agent.model.type.TrackActionType;
 import com.cmclinnovations.agent.service.AddService;
 import com.cmclinnovations.agent.service.DeleteService;
@@ -36,8 +36,6 @@ public class LifecycleTaskBatchService {
   private final LifecycleQueryService lifecycleQueryService;
   private final LifecycleTaskService lifecycleTaskService;
   private final ResponseEntityBuilder responseEntityBuilder;
-
-  private static final String ORDER_DISPATCH_MESSAGE = "Order has been assigned and is awaiting execution.";
 
   public LifecycleTaskBatchService(AddService addService, ChangelogService changelogService,
       DateTimeService dateTimeService, DeleteService deleteService, LifecycleQueryService lifecycleQueryService,
@@ -61,30 +59,31 @@ public class LifecycleTaskBatchService {
    */
   public ResponseEntity<StandardApiResponse<?>> updateTaskEventDetails(String type,
       List<Map<String, Object>> items) {
-    BatchEventConfig config = this.getConfig(type);
+    LifecycleTaskOperationType config = this.getConfig(type);
     List<String> taskIds = this.validateAndGetTaskIds(items);
+    LifecycleEventType[] previousEventTypes = config.getPreviousEventTypes();
 
     Map<String, String> previousOccurrences = this.lifecycleTaskService.getPreviousOccurrences(
-        taskIds, QueryResource.IRI_KEY, config.previousEventTypes());
+        taskIds, QueryResource.IRI_KEY, previousEventTypes);
     this.requirePreviousOccurrences(taskIds, previousOccurrences);
 
     // Reuse predecessor results when activity history targets the same event type.
-    Map<String, String> activityTargets = Arrays.equals(
-        config.activityTargetEventTypes(), config.previousEventTypes())
+    LifecycleEventType[] activityTargetEventTypes = config.getActivityTargetEventTypes();
+    Map<String, String> activityTargets = Arrays.equals(activityTargetEventTypes, previousEventTypes)
         ? previousOccurrences
         : this.lifecycleTaskService.getPreviousOccurrences(
-            taskIds, QueryResource.IRI_KEY, config.activityTargetEventTypes());
+            taskIds, QueryResource.IRI_KEY, activityTargetEventTypes);
     this.requirePreviousOccurrences(taskIds, activityTargets);
 
     this.prepareItems(items, previousOccurrences, config);
 
     ResponseEntity<StandardApiResponse<?>> response = this.deleteService.deleteLifecycleOccurrences(
-        config.eventType().getId(), taskIds, config.eventType());
+        config.getEventType().getId(), taskIds, config.getEventType());
     if (response.getStatusCode() != HttpStatus.OK) {
       return response;
     }
 
-    response = this.addService.instantiateBatch(Map.of(config.eventType().getId(), items));
+    response = this.addService.instantiateBatch(Map.of(config.getEventType().getId(), items));
     if (response.getStatusCode() != HttpStatus.OK) {
       return response;
     }
@@ -93,14 +92,14 @@ public class LifecycleTaskBatchService {
     String agentIri = this.instantiateAgent();
     List<String> activityTargetIris = taskIds.stream().map(activityTargets::get).toList();
     List<Map<String, Object>> activityParams = this.changelogService.prepareActivities(
-        activityTargetIris, config.trackAction(), agentIri);
+        activityTargetIris, config.getTrackAction(), agentIri);
     response = this.addService.instantiateBatch(Map.of(QueryResource.HISTORY_ACTIVITY_RESOURCE, activityParams));
     if (response.getStatusCode() != HttpStatus.OK) {
       return response;
     }
 
     return this.responseEntityBuilder.success("task",
-        LocalisationTranslator.getMessage(config.successMessageKey()));
+        LocalisationTranslator.getMessage(config.getBulkSuccessMessageKey()));
   }
 
   /**
@@ -124,23 +123,13 @@ public class LifecycleTaskBatchService {
    * @param type Lifecycle operation type.
    * @return Configuration for processing the requested operation.
    */
-  private BatchEventConfig getConfig(String type) {
-    if (type == null) {
+  private LifecycleTaskOperationType getConfig(String type) {
+    LifecycleTaskOperationType config = LifecycleTaskOperationType.fromId(type);
+    if (config == null || !config.supportsBulk()) {
       throw new IllegalArgumentException(
           LocalisationTranslator.getMessage(LocalisationResource.ERROR_INVALID_EVENT_TYPE_KEY));
     }
-    return switch (type.toLowerCase(Locale.ROOT)) {
-      case "dispatch" -> new BatchEventConfig(
-          LifecycleEventType.SERVICE_ORDER_DISPATCHED,
-          new LifecycleEventType[] { LifecycleEventType.SERVICE_ORDER_RECEIVED },
-          new LifecycleEventType[] { LifecycleEventType.SERVICE_ORDER_RECEIVED },
-          TrackActionType.ASSIGNMENT,
-          ORDER_DISPATCH_MESSAGE,
-          null,
-          LocalisationResource.SUCCESS_CONTRACT_TASK_BULK_ASSIGN_KEY);
-      default -> throw new IllegalArgumentException(
-          LocalisationTranslator.getMessage(LocalisationResource.ERROR_INVALID_EVENT_TYPE_KEY));
-    };
+    return config;
   }
 
   /**
@@ -215,43 +204,22 @@ public class LifecycleTaskBatchService {
    * @param config              Lifecycle operation configuration.
    */
   private void prepareItems(List<Map<String, Object>> items, Map<String, String> previousOccurrences,
-      BatchEventConfig config) {
+      LifecycleTaskOperationType config) {
     // Reuse the stage IRI for tasks belonging to the same contract.
     Map<String, String> stagesByContract = new HashMap<>();
     for (Map<String, Object> item : items) {
       String contractId = item.get(LifecycleResource.CONTRACT_KEY).toString();
       String stage = stagesByContract.computeIfAbsent(contractId,
           id -> this.lifecycleQueryService.getInstance(FileService.CONTRACT_STAGE_QUERY_RESOURCE, id,
-              config.eventType().getStage()).getFieldValue(QueryResource.IRI_KEY));
+              config.getEventType().getStage()).getFieldValue(QueryResource.IRI_KEY));
 
       item.put(LifecycleResource.DATE_TIME_KEY, this.dateTimeService.getCurrentDateTime());
       item.put(LifecycleResource.STAGE_KEY, stage);
-      item.put(LifecycleResource.REMARKS_KEY, config.remarks());
+      item.put(LifecycleResource.REMARKS_KEY, config.getRemarks());
       item.put(LifecycleResource.ORDER_KEY, previousOccurrences.get(item.get(QueryResource.ID_KEY).toString()));
-      if (config.eventStatus() != null) {
-        item.put(LifecycleResource.EVENT_STATUS_KEY, config.eventStatus());
+      if (config.getEventStatus() != null) {
+        item.put(LifecycleResource.EVENT_STATUS_KEY, config.getEventStatus());
       }
     }
-  }
-
-  /**
-   * Configuration required to process one supported batch lifecycle event.
-   *
-   * @param eventType                Lifecycle event to create.
-   * @param previousEventTypes       Allowed predecessor events in fallback order.
-   * @param activityTargetEventTypes Events targeted by the resulting activities.
-   * @param trackAction              Activity action to record.
-   * @param remarks                  Remarks assigned to each lifecycle event.
-   * @param eventStatus              Optional status assigned to each event.
-   * @param successMessageKey        Localised success message key.
-   */
-  private record BatchEventConfig(
-      LifecycleEventType eventType,
-      LifecycleEventType[] previousEventTypes,
-      LifecycleEventType[] activityTargetEventTypes,
-      TrackActionType trackAction,
-      String remarks,
-      String eventStatus,
-      String successMessageKey) {
   }
 }

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -1092,7 +1092,7 @@ public class LifecycleTaskService {
 
     // Delete the terminal occurrence and log its reversal on success
     ResponseEntity<StandardApiResponse<?>> response = this.deleteService.deleteLifecycleOccurrences(
-        eventType.getId(), List.of(taskId), eventType);
+        eventType.getId(), Set.of(taskId), eventType);
     if (response.getStatusCode() == HttpStatus.OK && trackAction != TrackActionType.IGNORED) {
       this.addService.logActivity(orderEvent, trackAction);
     }

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -270,8 +270,9 @@ public class LifecycleTaskService {
               LocalisationTranslator.getMessage(LocalisationResource.ERROR_INVALID_DATE_CANCEL_KEY));
         }
 
-        String prevEventIri = this.getPreviousOccurrence(taskId, LifecycleEventType.SERVICE_ORDER_DISPATCHED,
-            LifecycleEventType.SERVICE_ORDER_RECEIVED);
+        String prevEventIri = this.requirePreviousOccurrence(taskId,
+            this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
+                List.of(LifecycleEventType.SERVICE_ORDER_DISPATCHED, LifecycleEventType.SERVICE_ORDER_RECEIVED)));
         params.put(LifecycleResource.ORDER_KEY, prevEventIri);
 
         return this.genOccurrence(LifecycleResource.CANCEL_RESOURCE, params, LifecycleEventType.SERVICE_CANCELLATION,
@@ -285,8 +286,9 @@ public class LifecycleTaskService {
               LocalisationTranslator.getMessage(LocalisationResource.ERROR_INVALID_DATE_REPORT_KEY));
         }
 
-        prevEventIri = this.getPreviousOccurrence(taskId, LifecycleEventType.SERVICE_ORDER_DISPATCHED,
-            LifecycleEventType.SERVICE_ORDER_RECEIVED);
+        prevEventIri = this.requirePreviousOccurrence(taskId,
+            this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
+                List.of(LifecycleEventType.SERVICE_ORDER_DISPATCHED, LifecycleEventType.SERVICE_ORDER_RECEIVED)));
         params.put(LifecycleResource.ORDER_KEY, prevEventIri);
 
         return this.genOccurrence(LifecycleResource.REPORT_RESOURCE, params, LifecycleEventType.SERVICE_INCIDENT_REPORT,
@@ -294,8 +296,10 @@ public class LifecycleTaskService {
             LocalisationResource.SUCCESS_CONTRACT_TASK_REPORT_KEY);
       case LifecycleEventType.SERVICE_VOID:
         LOGGER.info("Received request to void a service...");
-        prevEventIri = this.getPreviousOccurrence(taskId, LifecycleEventType.SERVICE_EXEMPT,
-            LifecycleEventType.SERVICE_CANCELLATION, LifecycleEventType.SERVICE_INCIDENT_REPORT);
+        prevEventIri = this.requirePreviousOccurrence(taskId,
+            this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
+                List.of(LifecycleEventType.SERVICE_EXEMPT, LifecycleEventType.SERVICE_CANCELLATION,
+                    LifecycleEventType.SERVICE_INCIDENT_REPORT)));
         params.put(LifecycleResource.ORDER_KEY, prevEventIri);
         params.put(LifecycleResource.REMARKS_KEY, SERVICE_VOID_MESSAGE);
 
@@ -304,8 +308,10 @@ public class LifecycleTaskService {
             LocalisationResource.SUCCESS_CONTRACT_TASK_VOID_KEY);
       case LifecycleEventType.SERVICE_EXEMPT:
         LOGGER.info("Received request to exempt the billable details for a service...");
-        prevEventIri = this.getPreviousOccurrence(taskId, LifecycleEventType.SERVICE_EXECUTION,
-            LifecycleEventType.SERVICE_CANCELLATION, LifecycleEventType.SERVICE_INCIDENT_REPORT);
+        prevEventIri = this.requirePreviousOccurrence(taskId,
+            this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
+                List.of(LifecycleEventType.SERVICE_EXECUTION, LifecycleEventType.SERVICE_CANCELLATION,
+                    LifecycleEventType.SERVICE_INCIDENT_REPORT)));
         params.put(LifecycleResource.ORDER_KEY, prevEventIri);
 
         return this.genOccurrence(LifecycleResource.EXEMPT_RESOURCE, params, LifecycleEventType.SERVICE_EXEMPT,
@@ -877,8 +883,9 @@ public class LifecycleTaskService {
     ResponseEntity<StandardApiResponse<?>> response = this.addService.instantiate(resourceId, params, successLogMessage,
         messageResource, TrackActionType.IGNORED);
     if (response.getStatusCode() == HttpStatus.OK && action != TrackActionType.IGNORED) {
-      String orderTask = this.getPreviousOccurrence(params.get(QueryResource.ID_KEY).toString(), QueryResource.IRI_KEY,
-          LifecycleEventType.SERVICE_ORDER_RECEIVED);
+      String taskId = params.get(QueryResource.ID_KEY).toString();
+      String orderTask = this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
+          List.of(LifecycleEventType.SERVICE_ORDER_RECEIVED)).get(taskId);
       this.addService.logActivity(orderTask, action);
     }
     return response;
@@ -1083,7 +1090,9 @@ public class LifecycleTaskService {
 
     // Retrieve the original order for history logging when required
     String orderEvent = trackAction == TrackActionType.IGNORED
-        ? null : this.getPreviousOccurrence(taskId, QueryResource.IRI_KEY, LifecycleEventType.SERVICE_ORDER_RECEIVED);
+        ? null
+        : this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
+            List.of(LifecycleEventType.SERVICE_ORDER_RECEIVED)).get(taskId);
     if (trackAction != TrackActionType.IGNORED && orderEvent == null) {
       return this.responseEntityBuilder.error(
           LocalisationTranslator.getMessage(LocalisationResource.ERROR_INVALID_INSTANCE_KEY), HttpStatus.NOT_FOUND);
@@ -1144,11 +1153,11 @@ public class LifecycleTaskService {
 
     String orderId = params.get(QueryResource.ID_KEY).toString();
     // Get the order received IRI
-    String orderEventIri = this.getPreviousOccurrence(orderId, QueryResource.IRI_KEY,
-        LifecycleEventType.SERVICE_ORDER_RECEIVED);
+    String orderEventIri = this.getPreviousOccurrences(List.of(orderId), QueryResource.IRI_KEY,
+        List.of(LifecycleEventType.SERVICE_ORDER_RECEIVED)).get(orderId);
     // Set previous occurrence
-    String previousOccurrenceIri = this.getPreviousOccurrence(orderId,
-        fallbackEvents.toArray(new LifecycleEventType[0]));
+    String previousOccurrenceIri = this.requirePreviousOccurrence(orderId,
+        this.getPreviousOccurrences(List.of(orderId), QueryResource.IRI_KEY, fallbackEvents));
     params.put(LifecycleResource.ORDER_KEY, previousOccurrenceIri);
     ResponseEntity<StandardApiResponse<?>> response = this.updateService.update(orderId, eventType.getId(),
         successMsgId, params, TrackActionType.IGNORED);
@@ -1159,38 +1168,60 @@ public class LifecycleTaskService {
   }
 
   /**
-   * Gets the previous occurence iri based on the possible events.
+   * Retrieves the previous occurrence instances based on their event types and
+   * latest event identifiers.
    * 
-   * @param eventId The identifier of the latest event in the succeeds chain.
-   * @param events  The plausible events that may be previous occurrence.
+   * @param latestEventIds The identifiers of the latest events in the succeeds
+   *                       chains.
+   * @param fieldKey       The field key to extract. Either id or iri.
+   * @param eventTypes     Target event types in fallback order.
    */
-  public String getPreviousOccurrence(String eventId, LifecycleEventType... events) {
-    String previousOccurrenceIri = null;
-    for (LifecycleEventType fallbackEvent : events) {
-      previousOccurrenceIri = this.getPreviousOccurrence(eventId, QueryResource.IRI_KEY, fallbackEvent);
-      if (previousOccurrenceIri != null) {
-        return previousOccurrenceIri;
-      }
+  public Map<String, String> getPreviousOccurrences(Collection<String> latestEventIds, String fieldKey,
+      Collection<LifecycleEventType> eventTypes) {
+    if (latestEventIds == null || latestEventIds.isEmpty()
+        || latestEventIds.stream().anyMatch(eventId -> eventId == null || eventId.isBlank())) {
+      throw new IllegalArgumentException("At least one event identifier is required!");
     }
-    if (previousOccurrenceIri == null) {
-      throw new NullPointerException("No valid previous occurrence found from fallback events!");
+    if (eventTypes == null || eventTypes.isEmpty() || eventTypes.stream().anyMatch(java.util.Objects::isNull)) {
+      throw new IllegalArgumentException("At least one previous event type is required!");
     }
-    return previousOccurrenceIri;
+
+    String eventIds = latestEventIds.stream()
+        .distinct()
+        .map(eventId -> Rdf.literalOf(eventId).getQueryString())
+        .collect(Collectors.joining(" "));
+    String previousEventTypes = eventTypes.stream()
+        .distinct()
+        .map(eventType -> Rdf.iri(eventType.getEvent()).getQueryString())
+        .collect(Collectors.joining(" "));
+    Queue<SparqlBinding> instances = this.lifecycleQueryService.getInstances(
+        FileService.CONTRACT_PREV_EVENT_QUERY_RESOURCE, eventIds, previousEventTypes);
+
+    Map<String, Map<String, String>> valuesByEventAndType = new HashMap<>();
+    for (SparqlBinding instance : instances) {
+      // TODO: parameterise variable name
+      valuesByEventAndType.computeIfAbsent(instance.getFieldValue("source_id"), _ -> new HashMap<>())
+          .putIfAbsent(instance.getFieldValue("previous_event_type"), instance.getFieldValue(fieldKey));
+    }
+
+    Map<String, String> previousOccurrences = new LinkedHashMap<>();
+    latestEventIds.stream().distinct().forEach(eventId -> {
+      Map<String, String> valuesByType = valuesByEventAndType.getOrDefault(eventId, Collections.emptyMap());
+      eventTypes.stream()
+          .map(eventType -> valuesByType.get(eventType.getEvent()))
+          .filter(java.util.Objects::nonNull)
+          .findFirst()
+          .ifPresent(value -> previousOccurrences.put(eventId, value));
+    });
+    return previousOccurrences;
   }
 
-  /**
-   * Retrieves the previous occurrence instance based on its event type and latest
-   * event id.
-   * 
-   * @param latestEventId The identifier of the latest event in the succeeds
-   *                      chain.
-   * @param fieldKey      The field key to extract. Either id or iri.
-   * @param eventType     Target event type to query for.
-   */
-  public String getPreviousOccurrence(String latestEventId, String fieldKey, LifecycleEventType eventType) {
-    SparqlBinding instance = this.lifecycleQueryService
-        .getInstance(FileService.CONTRACT_PREV_EVENT_QUERY_RESOURCE, true, latestEventId, eventType.getEvent());
-    return instance == null ? null : instance.getFieldValue(fieldKey);
+  private String requirePreviousOccurrence(String eventId, Map<String, String> previousOccurrences) {
+    String previousOccurrence = previousOccurrences.get(eventId);
+    if (previousOccurrence == null) {
+      throw new NullPointerException("No valid previous occurrence found from fallback events!");
+    }
+    return previousOccurrence;
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -271,9 +271,8 @@ public class LifecycleTaskService {
               LocalisationTranslator.getMessage(LocalisationResource.ERROR_INVALID_DATE_CANCEL_KEY));
         }
 
-        String prevEventIri = this.requirePreviousOccurrence(taskId,
-            this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
-                LifecycleEventType.SERVICE_ORDER_DISPATCHED, LifecycleEventType.SERVICE_ORDER_RECEIVED));
+        String prevEventIri = this.getPreviousOccurrence(taskId,
+            LifecycleEventType.SERVICE_ORDER_DISPATCHED, LifecycleEventType.SERVICE_ORDER_RECEIVED);
         params.put(LifecycleResource.ORDER_KEY, prevEventIri);
 
         return this.genOccurrence(LifecycleResource.CANCEL_RESOURCE, params, LifecycleEventType.SERVICE_CANCELLATION,
@@ -287,9 +286,8 @@ public class LifecycleTaskService {
               LocalisationTranslator.getMessage(LocalisationResource.ERROR_INVALID_DATE_REPORT_KEY));
         }
 
-        prevEventIri = this.requirePreviousOccurrence(taskId,
-            this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
-                LifecycleEventType.SERVICE_ORDER_DISPATCHED, LifecycleEventType.SERVICE_ORDER_RECEIVED));
+        prevEventIri = this.getPreviousOccurrence(taskId,
+            LifecycleEventType.SERVICE_ORDER_DISPATCHED, LifecycleEventType.SERVICE_ORDER_RECEIVED);
         params.put(LifecycleResource.ORDER_KEY, prevEventIri);
 
         return this.genOccurrence(LifecycleResource.REPORT_RESOURCE, params, LifecycleEventType.SERVICE_INCIDENT_REPORT,
@@ -297,10 +295,9 @@ public class LifecycleTaskService {
             LocalisationResource.SUCCESS_CONTRACT_TASK_REPORT_KEY);
       case LifecycleEventType.SERVICE_VOID:
         LOGGER.info("Received request to void a service...");
-        prevEventIri = this.requirePreviousOccurrence(taskId,
-            this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
-                LifecycleEventType.SERVICE_EXEMPT, LifecycleEventType.SERVICE_CANCELLATION,
-                LifecycleEventType.SERVICE_INCIDENT_REPORT));
+        prevEventIri = this.getPreviousOccurrence(taskId,
+            LifecycleEventType.SERVICE_EXEMPT, LifecycleEventType.SERVICE_CANCELLATION,
+            LifecycleEventType.SERVICE_INCIDENT_REPORT);
         params.put(LifecycleResource.ORDER_KEY, prevEventIri);
         params.put(LifecycleResource.REMARKS_KEY, SERVICE_VOID_MESSAGE);
 
@@ -309,10 +306,9 @@ public class LifecycleTaskService {
             LocalisationResource.SUCCESS_CONTRACT_TASK_VOID_KEY);
       case LifecycleEventType.SERVICE_EXEMPT:
         LOGGER.info("Received request to exempt the billable details for a service...");
-        prevEventIri = this.requirePreviousOccurrence(taskId,
-            this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
-                LifecycleEventType.SERVICE_EXECUTION, LifecycleEventType.SERVICE_CANCELLATION,
-                LifecycleEventType.SERVICE_INCIDENT_REPORT));
+        prevEventIri = this.getPreviousOccurrence(taskId,
+            LifecycleEventType.SERVICE_EXECUTION, LifecycleEventType.SERVICE_CANCELLATION,
+            LifecycleEventType.SERVICE_INCIDENT_REPORT);
         params.put(LifecycleResource.ORDER_KEY, prevEventIri);
 
         return this.genOccurrence(LifecycleResource.EXEMPT_RESOURCE, params, LifecycleEventType.SERVICE_EXEMPT,
@@ -1157,9 +1153,8 @@ public class LifecycleTaskService {
     String orderEventIri = this.getPreviousOccurrences(List.of(orderId), QueryResource.IRI_KEY,
         LifecycleEventType.SERVICE_ORDER_RECEIVED).get(orderId);
     // Set previous occurrence
-    String previousOccurrenceIri = this.requirePreviousOccurrence(orderId,
-        this.getPreviousOccurrences(List.of(orderId), QueryResource.IRI_KEY,
-            fallbackEvents.toArray(LifecycleEventType[]::new)));
+    String previousOccurrenceIri = this.getPreviousOccurrence(orderId,
+        fallbackEvents.toArray(LifecycleEventType[]::new));
     params.put(LifecycleResource.ORDER_KEY, previousOccurrenceIri);
     ResponseEntity<StandardApiResponse<?>> response = this.updateService.update(orderId, eventType.getId(),
         successMsgId, params, TrackActionType.IGNORED);
@@ -1167,6 +1162,18 @@ public class LifecycleTaskService {
       this.addService.logActivity(orderEventIri, action);
     }
     return response;
+  }
+
+  /**
+   * Gets the previous occurrence IRI based on the possible event types.
+   *
+   * @param eventId    The identifier of the latest event in the succeeds chain.
+   * @param eventTypes The plausible event types in fallback order.
+   * @return Previous occurrence IRI.
+   */
+  public String getPreviousOccurrence(String eventId, LifecycleEventType... eventTypes) {
+    return this.requirePreviousOccurrence(eventId,
+        this.getPreviousOccurrences(Collections.singletonList(eventId), QueryResource.IRI_KEY, eventTypes));
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -1186,6 +1186,7 @@ public class LifecycleTaskService {
       throw new IllegalArgumentException("At least one previous event type is required!");
     }
 
+    // Format collection inputs for the query's VALUES blocks.
     String eventIds = latestEventIds.stream()
         .distinct()
         .map(eventId -> Rdf.literalOf(eventId).getQueryString())
@@ -1197,6 +1198,7 @@ public class LifecycleTaskService {
     Queue<SparqlBinding> instances = this.lifecycleQueryService.getInstances(
         FileService.CONTRACT_PREV_EVENT_QUERY_RESOURCE, eventIds, previousEventTypes);
 
+    // Index results by source ID and predecessor type before applying fallback order.
     Map<String, Map<String, String>> valuesByEventAndType = new HashMap<>();
     for (SparqlBinding instance : instances) {
       // TODO: parameterise variable name
@@ -1207,6 +1209,7 @@ public class LifecycleTaskService {
     Map<String, String> previousOccurrences = new LinkedHashMap<>();
     latestEventIds.stream().distinct().forEach(eventId -> {
       Map<String, String> valuesByType = valuesByEventAndType.getOrDefault(eventId, Collections.emptyMap());
+      // Preserve the caller's event-type order as the fallback priority.
       eventTypes.stream()
           .map(eventType -> valuesByType.get(eventType.getEvent()))
           .filter(java.util.Objects::nonNull)

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -1204,9 +1204,10 @@ public class LifecycleTaskService {
     // Index results by source ID and predecessor type before applying fallback order.
     Map<String, Map<String, String>> valuesByEventAndType = new HashMap<>();
     for (SparqlBinding instance : instances) {
-      // TODO: parameterise variable name
-      valuesByEventAndType.computeIfAbsent(instance.getFieldValue("source_id"), _ -> new HashMap<>())
-          .putIfAbsent(instance.getFieldValue("previous_event_type"), instance.getFieldValue(fieldKey));
+      valuesByEventAndType.computeIfAbsent(instance.getFieldValue(QueryResource.EVENT_ID_VAR.getVarName()),
+          _ -> new HashMap<>())
+          .putIfAbsent(instance.getFieldValue(QueryResource.PREVIOUS_EVENT_TYPE_VAR.getVarName()),
+              instance.getFieldValue(fieldKey));
     }
 
     Map<String, String> previousOccurrences = new LinkedHashMap<>();

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -2,6 +2,7 @@ package com.cmclinnovations.agent.service.application;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -272,7 +273,7 @@ public class LifecycleTaskService {
 
         String prevEventIri = this.requirePreviousOccurrence(taskId,
             this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
-                List.of(LifecycleEventType.SERVICE_ORDER_DISPATCHED, LifecycleEventType.SERVICE_ORDER_RECEIVED)));
+                LifecycleEventType.SERVICE_ORDER_DISPATCHED, LifecycleEventType.SERVICE_ORDER_RECEIVED));
         params.put(LifecycleResource.ORDER_KEY, prevEventIri);
 
         return this.genOccurrence(LifecycleResource.CANCEL_RESOURCE, params, LifecycleEventType.SERVICE_CANCELLATION,
@@ -288,7 +289,7 @@ public class LifecycleTaskService {
 
         prevEventIri = this.requirePreviousOccurrence(taskId,
             this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
-                List.of(LifecycleEventType.SERVICE_ORDER_DISPATCHED, LifecycleEventType.SERVICE_ORDER_RECEIVED)));
+                LifecycleEventType.SERVICE_ORDER_DISPATCHED, LifecycleEventType.SERVICE_ORDER_RECEIVED));
         params.put(LifecycleResource.ORDER_KEY, prevEventIri);
 
         return this.genOccurrence(LifecycleResource.REPORT_RESOURCE, params, LifecycleEventType.SERVICE_INCIDENT_REPORT,
@@ -298,8 +299,8 @@ public class LifecycleTaskService {
         LOGGER.info("Received request to void a service...");
         prevEventIri = this.requirePreviousOccurrence(taskId,
             this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
-                List.of(LifecycleEventType.SERVICE_EXEMPT, LifecycleEventType.SERVICE_CANCELLATION,
-                    LifecycleEventType.SERVICE_INCIDENT_REPORT)));
+                LifecycleEventType.SERVICE_EXEMPT, LifecycleEventType.SERVICE_CANCELLATION,
+                LifecycleEventType.SERVICE_INCIDENT_REPORT));
         params.put(LifecycleResource.ORDER_KEY, prevEventIri);
         params.put(LifecycleResource.REMARKS_KEY, SERVICE_VOID_MESSAGE);
 
@@ -310,8 +311,8 @@ public class LifecycleTaskService {
         LOGGER.info("Received request to exempt the billable details for a service...");
         prevEventIri = this.requirePreviousOccurrence(taskId,
             this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
-                List.of(LifecycleEventType.SERVICE_EXECUTION, LifecycleEventType.SERVICE_CANCELLATION,
-                    LifecycleEventType.SERVICE_INCIDENT_REPORT)));
+                LifecycleEventType.SERVICE_EXECUTION, LifecycleEventType.SERVICE_CANCELLATION,
+                LifecycleEventType.SERVICE_INCIDENT_REPORT));
         params.put(LifecycleResource.ORDER_KEY, prevEventIri);
 
         return this.genOccurrence(LifecycleResource.EXEMPT_RESOURCE, params, LifecycleEventType.SERVICE_EXEMPT,
@@ -885,7 +886,7 @@ public class LifecycleTaskService {
     if (response.getStatusCode() == HttpStatus.OK && action != TrackActionType.IGNORED) {
       String taskId = params.get(QueryResource.ID_KEY).toString();
       String orderTask = this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
-          List.of(LifecycleEventType.SERVICE_ORDER_RECEIVED)).get(taskId);
+          LifecycleEventType.SERVICE_ORDER_RECEIVED).get(taskId);
       this.addService.logActivity(orderTask, action);
     }
     return response;
@@ -1092,7 +1093,7 @@ public class LifecycleTaskService {
     String orderEvent = trackAction == TrackActionType.IGNORED
         ? null
         : this.getPreviousOccurrences(List.of(taskId), QueryResource.IRI_KEY,
-            List.of(LifecycleEventType.SERVICE_ORDER_RECEIVED)).get(taskId);
+            LifecycleEventType.SERVICE_ORDER_RECEIVED).get(taskId);
     if (trackAction != TrackActionType.IGNORED && orderEvent == null) {
       return this.responseEntityBuilder.error(
           LocalisationTranslator.getMessage(LocalisationResource.ERROR_INVALID_INSTANCE_KEY), HttpStatus.NOT_FOUND);
@@ -1154,10 +1155,11 @@ public class LifecycleTaskService {
     String orderId = params.get(QueryResource.ID_KEY).toString();
     // Get the order received IRI
     String orderEventIri = this.getPreviousOccurrences(List.of(orderId), QueryResource.IRI_KEY,
-        List.of(LifecycleEventType.SERVICE_ORDER_RECEIVED)).get(orderId);
+        LifecycleEventType.SERVICE_ORDER_RECEIVED).get(orderId);
     // Set previous occurrence
     String previousOccurrenceIri = this.requirePreviousOccurrence(orderId,
-        this.getPreviousOccurrences(List.of(orderId), QueryResource.IRI_KEY, fallbackEvents));
+        this.getPreviousOccurrences(List.of(orderId), QueryResource.IRI_KEY,
+            fallbackEvents.toArray(LifecycleEventType[]::new)));
     params.put(LifecycleResource.ORDER_KEY, previousOccurrenceIri);
     ResponseEntity<StandardApiResponse<?>> response = this.updateService.update(orderId, eventType.getId(),
         successMsgId, params, TrackActionType.IGNORED);
@@ -1177,12 +1179,13 @@ public class LifecycleTaskService {
    * @param eventTypes     Target event types in fallback order.
    */
   public Map<String, String> getPreviousOccurrences(Collection<String> latestEventIds, String fieldKey,
-      Collection<LifecycleEventType> eventTypes) {
+      LifecycleEventType... eventTypes) {
     if (latestEventIds == null || latestEventIds.isEmpty()
         || latestEventIds.stream().anyMatch(eventId -> eventId == null || eventId.isBlank())) {
       throw new IllegalArgumentException("At least one event identifier is required!");
     }
-    if (eventTypes == null || eventTypes.isEmpty() || eventTypes.stream().anyMatch(java.util.Objects::isNull)) {
+    if (eventTypes == null || eventTypes.length == 0
+        || Arrays.stream(eventTypes).anyMatch(java.util.Objects::isNull)) {
       throw new IllegalArgumentException("At least one previous event type is required!");
     }
 
@@ -1191,7 +1194,7 @@ public class LifecycleTaskService {
         .distinct()
         .map(eventId -> Rdf.literalOf(eventId).getQueryString())
         .collect(Collectors.joining(" "));
-    String previousEventTypes = eventTypes.stream()
+    String previousEventTypes = Arrays.stream(eventTypes)
         .distinct()
         .map(eventType -> Rdf.iri(eventType.getEvent()).getQueryString())
         .collect(Collectors.joining(" "));
@@ -1210,7 +1213,7 @@ public class LifecycleTaskService {
     latestEventIds.stream().distinct().forEach(eventId -> {
       Map<String, String> valuesByType = valuesByEventAndType.getOrDefault(eventId, Collections.emptyMap());
       // Preserve the caller's event-type order as the fallback priority.
-      eventTypes.stream()
+      Arrays.stream(eventTypes)
           .map(eventType -> valuesByType.get(eventType.getEvent()))
           .filter(java.util.Objects::nonNull)
           .findFirst()

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -1099,8 +1099,8 @@ public class LifecycleTaskService {
     }
 
     // Delete the terminal occurrence and log its reversal on success
-    ResponseEntity<StandardApiResponse<?>> response = this.deleteService.deleteLifecycleOccurrence(
-        eventType.getId(), taskId, eventType);
+    ResponseEntity<StandardApiResponse<?>> response = this.deleteService.deleteLifecycleOccurrences(
+        eventType.getId(), List.of(taskId), eventType);
     if (response.getStatusCode() == HttpStatus.OK && trackAction != TrackActionType.IGNORED) {
       this.addService.logActivity(orderEvent, trackAction);
     }

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -65,11 +65,6 @@ public class LifecycleTaskService {
   private final List<ColumnMetaPayload> taskColumnMeta = new ArrayList<>();
   private final List<ColumnMetaPayload> taskEntityColumnMeta = new ArrayList<>();
 
-  private static final String ORDER_INITIALISE_MESSAGE = "Order received and is being processed.";
-  private static final String ORDER_DISPATCH_MESSAGE = "Order has been assigned and is awaiting execution.";
-  private static final String ORDER_COMPLETE_MESSAGE = "Order has been completed successfully.";
-  private static final String ORDER_ACCRUAL_MESSAGE = "Billables have been accrued successfully.";
-  private static final String SERVICE_VOID_MESSAGE = "Service has been voided.";
   private static final int NUM_DAY_ORDER_GEN = 30;
   static final Logger LOGGER = LogManager.getLogger(LifecycleTaskService.class);
 
@@ -299,7 +294,7 @@ public class LifecycleTaskService {
             LifecycleEventType.SERVICE_EXEMPT, LifecycleEventType.SERVICE_CANCELLATION,
             LifecycleEventType.SERVICE_INCIDENT_REPORT);
         params.put(LifecycleResource.ORDER_KEY, prevEventIri);
-        params.put(LifecycleResource.REMARKS_KEY, SERVICE_VOID_MESSAGE);
+        params.put(LifecycleResource.REMARKS_KEY, LifecycleResource.SERVICE_VOID_MESSAGE);
 
         return this.genOccurrence(LifecycleResource.VOID_RESOURCE, params, LifecycleEventType.SERVICE_VOID,
             TrackActionType.IGNORED, "Task has been successfully voided!",
@@ -959,7 +954,7 @@ public class LifecycleTaskService {
     // Add parameter template
     Map<String, Object> params = new HashMap<>();
     params.put(LifecycleResource.CONTRACT_KEY, contract);
-    params.put(LifecycleResource.REMARKS_KEY, ORDER_INITIALISE_MESSAGE);
+    params.put(LifecycleResource.REMARKS_KEY, LifecycleResource.ORDER_INITIALISE_MESSAGE);
     this.lifecycleQueryService.addOccurrenceParams(params, LifecycleEventType.SERVICE_ORDER_RECEIVED);
     String orderPrefix = StringResource.getPrefix(params.get(LifecycleResource.STAGE_KEY).toString());
     // Instantiate each occurrence
@@ -997,7 +992,7 @@ public class LifecycleTaskService {
     Map<String, Object> params = new HashMap<>();
     // Contract ID is mandatory to help generate the other related parameters
     params.put(LifecycleResource.CONTRACT_KEY, contractId);
-    params.put(LifecycleResource.REMARKS_KEY, ORDER_INITIALISE_MESSAGE);
+    params.put(LifecycleResource.REMARKS_KEY, LifecycleResource.ORDER_INITIALISE_MESSAGE);
     params.put(LifecycleResource.DATE_TIME_KEY, currentDateTime);
     this.lifecycleQueryService.addOccurrenceParams(params, LifecycleEventType.SERVICE_ORDER_RECEIVED);
     // Generate a new unique ID for the occurrence by retrieving the prefix from the
@@ -1023,7 +1018,7 @@ public class LifecycleTaskService {
                         SparqlResponseField.class).value()
                     : ""));
         params.putAll(currentEntity);
-        params.put(LifecycleResource.REMARKS_KEY, ORDER_DISPATCH_MESSAGE);
+        params.put(LifecycleResource.REMARKS_KEY, LifecycleResource.ORDER_DISPATCH_MESSAGE);
         // Ensure new task ID is kept
         params.put(QueryResource.ID_KEY, newTaskId);
         LifecycleResource.genIdAndInstanceParameters(defaultPrefix, LifecycleEventType.SERVICE_ORDER_DISPATCHED,
@@ -1121,17 +1116,17 @@ public class LifecycleTaskService {
     params.put(LifecycleResource.DATE_TIME_KEY, this.dateTimeService.getCurrentDateTime());
     switch (eventType) {
       case LifecycleEventType.SERVICE_EXECUTION:
-        remarksMsg = ORDER_COMPLETE_MESSAGE;
+        remarksMsg = LifecycleResource.ORDER_COMPLETE_MESSAGE;
         successMsgId = LocalisationResource.SUCCESS_CONTRACT_TASK_COMPLETE_KEY;
         fallbackEvents.add(LifecycleEventType.SERVICE_ORDER_DISPATCHED);
         break;
       case LifecycleEventType.SERVICE_ORDER_DISPATCHED:
-        remarksMsg = ORDER_DISPATCH_MESSAGE;
+        remarksMsg = LifecycleResource.ORDER_DISPATCH_MESSAGE;
         successMsgId = LocalisationResource.SUCCESS_CONTRACT_TASK_ASSIGN_KEY;
         fallbackEvents.add(LifecycleEventType.SERVICE_ORDER_RECEIVED);
         break;
       case LifecycleEventType.SERVICE_ACCRUAL:
-        remarksMsg = ORDER_ACCRUAL_MESSAGE;
+        remarksMsg = LifecycleResource.ORDER_ACCRUAL_MESSAGE;
         successMsgId = LocalisationResource.SUCCESS_CONTRACT_TASK_ACCRUAL_KEY;
         fallbackEvents.add(LifecycleEventType.SERVICE_EXECUTION);
         fallbackEvents.add(LifecycleEventType.SERVICE_CANCELLATION);

--- a/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/application/LifecycleTaskService.java
@@ -1172,8 +1172,12 @@ public class LifecycleTaskService {
    * @return Previous occurrence IRI.
    */
   public String getPreviousOccurrence(String eventId, LifecycleEventType... eventTypes) {
-    return this.requirePreviousOccurrence(eventId,
-        this.getPreviousOccurrences(Collections.singletonList(eventId), QueryResource.IRI_KEY, eventTypes));
+    String previousOccurrence = this.getPreviousOccurrences(
+        Collections.singletonList(eventId), QueryResource.IRI_KEY, eventTypes).get(eventId);
+    if (previousOccurrence == null) {
+      throw new NullPointerException("No valid previous occurrence found from fallback events!");
+    }
+    return previousOccurrence;
   }
 
   /**
@@ -1228,14 +1232,6 @@ public class LifecycleTaskService {
           .ifPresent(value -> previousOccurrences.put(eventId, value));
     });
     return previousOccurrences;
-  }
-
-  private String requirePreviousOccurrence(String eventId, Map<String, String> previousOccurrences) {
-    String previousOccurrence = previousOccurrences.get(eventId);
-    if (previousOccurrence == null) {
-      throw new NullPointerException("No valid previous occurrence found from fallback events!");
-    }
-    return previousOccurrence;
   }
 
   /**

--- a/agent/src/main/java/com/cmclinnovations/agent/service/core/ChangelogService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/core/ChangelogService.java
@@ -39,7 +39,7 @@ public class ChangelogService {
    * @param action The action to be logged.
    */
   public Map<String, Object> logAction(String iri, TrackActionType action) {
-    return this.prepareActivity(iri, action, this.dateTimeService.getCurrentDateTime());
+    return this.genActivityLog(iri, action, this.dateTimeService.getCurrentDateTime());
   }
 
   /**
@@ -50,7 +50,7 @@ public class ChangelogService {
    * @param action   Action to log for every entity.
    * @param agentIri Optional agent IRI shared by the activities.
    */
-  public List<Map<String, Object>> prepareActivities(Collection<String> iris, TrackActionType action,
+  public List<Map<String, Object>> logActions(Collection<String> iris, TrackActionType action,
       String agentIri) {
     if (iris == null || iris.isEmpty() || iris.stream().anyMatch(iri -> iri == null || iri.isBlank())) {
       throw new IllegalArgumentException("At least one affected entity IRI is required!");
@@ -59,7 +59,7 @@ public class ChangelogService {
     String timestamp = this.dateTimeService.getCurrentDateTime();
     List<Map<String, Object>> activities = new ArrayList<>();
     for (String iri : iris) {
-      Map<String, Object> activity = this.prepareActivity(iri, action, timestamp);
+      Map<String, Object> activity = this.genActivityLog(iri, action, timestamp);
       // Assign IDs before the activity maps are rendered as one payload.
       activity.put(QueryResource.ID_KEY, UUID.randomUUID().toString());
       if (agentIri != null && !agentIri.isBlank()) {
@@ -70,7 +70,14 @@ public class ChangelogService {
     return activities;
   }
 
-  private Map<String, Object> prepareActivity(String iri, TrackActionType action, String timestamp) {
+  /**
+   * Generates activity log replacements with a specified timestamp.
+   *
+   * @param iri       Entity IRI affected by the action.
+   * @param action    Action recorded by the activity.
+   * @param timestamp Timestamp shared by activities from the same operation.
+   */
+  private Map<String, Object> genActivityLog(String iri, TrackActionType action, String timestamp) {
     if (action == TrackActionType.IGNORED) {
       throw new IllegalArgumentException("TrackActionType.IGNORED is not a valid action for logging.");
     }

--- a/agent/src/main/java/com/cmclinnovations/agent/service/core/ChangelogService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/core/ChangelogService.java
@@ -1,7 +1,11 @@
 package com.cmclinnovations.agent.service.core;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 
@@ -35,14 +39,43 @@ public class ChangelogService {
    * @param action The action to be logged.
    */
   public Map<String, Object> logAction(String iri, TrackActionType action) {
+    return this.prepareActivity(iri, action, this.dateTimeService.getCurrentDateTime());
+  }
+
+  /**
+   * Generates activity replacements for multiple affected entities without
+   * persisting them.
+   *
+   * @param iris     Entity IRIs affected by the action.
+   * @param action   Action to log for every entity.
+   * @param agentIri Optional agent IRI shared by the activities.
+   */
+  public List<Map<String, Object>> prepareActivities(Collection<String> iris, TrackActionType action,
+      String agentIri) {
+    if (iris == null || iris.isEmpty() || iris.stream().anyMatch(iri -> iri == null || iri.isBlank())) {
+      throw new IllegalArgumentException("At least one affected entity IRI is required!");
+    }
+    String timestamp = this.dateTimeService.getCurrentDateTime();
+    List<Map<String, Object>> activities = new ArrayList<>();
+    for (String iri : iris) {
+      Map<String, Object> activity = this.prepareActivity(iri, action, timestamp);
+      activity.put(QueryResource.ID_KEY, UUID.randomUUID().toString());
+      if (agentIri != null && !agentIri.isBlank()) {
+        activity.put(QueryResource.HISTORY_AGENT_RESOURCE, agentIri);
+      }
+      activities.add(activity);
+    }
+    return activities;
+  }
+
+  private Map<String, Object> prepareActivity(String iri, TrackActionType action, String timestamp) {
     if (action == TrackActionType.IGNORED) {
       throw new IllegalArgumentException("TrackActionType.IGNORED is not a valid action for logging.");
     }
-    String currentDateTime = this.dateTimeService.getCurrentDateTime();
     Map<String, Object> replacements = new HashMap<>();
     replacements.put(QueryResource.IRI_KEY, iri);
     replacements.put(QueryResource.HISTORY_ACTIVITY_RESOURCE, action.getClazz());
-    replacements.put(LifecycleResource.TIMESTAMP_KEY, currentDateTime);
+    replacements.put(LifecycleResource.TIMESTAMP_KEY, timestamp);
     return replacements;
   }
 

--- a/agent/src/main/java/com/cmclinnovations/agent/service/core/ChangelogService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/core/ChangelogService.java
@@ -55,10 +55,12 @@ public class ChangelogService {
     if (iris == null || iris.isEmpty() || iris.stream().anyMatch(iri -> iri == null || iri.isBlank())) {
       throw new IllegalArgumentException("At least one affected entity IRI is required!");
     }
+    // Use one timestamp for every activity in the same batch action.
     String timestamp = this.dateTimeService.getCurrentDateTime();
     List<Map<String, Object>> activities = new ArrayList<>();
     for (String iri : iris) {
       Map<String, Object> activity = this.prepareActivity(iri, action, timestamp);
+      // Assign IDs before the activity maps are rendered as one payload.
       activity.put(QueryResource.ID_KEY, UUID.randomUUID().toString());
       if (agentIri != null && !agentIri.isBlank()) {
         activity.put(QueryResource.HISTORY_AGENT_RESOURCE, agentIri);

--- a/agent/src/main/java/com/cmclinnovations/agent/service/core/KGService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/core/KGService.java
@@ -98,10 +98,9 @@ public class KGService {
   /**
    * Deletes the target instance and its associated properties from the KG.
    * 
-   * @param query    The DELETE query for execution.
-   * @param targetId The target instance IRI.
+   * @param query The DELETE query for execution.
    */
-  public ResponseEntity<StandardApiResponse<?>> delete(String query, String targetId) {
+  public ResponseEntity<StandardApiResponse<?>> delete(String query) {
     LOGGER.debug("Deleting instances...");
     int statusCode = this.executeUpdate(query);
     if (statusCode == 200) {

--- a/agent/src/main/java/com/cmclinnovations/agent/service/core/QueryTemplateService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/core/QueryTemplateService.java
@@ -3,6 +3,7 @@ package com.cmclinnovations.agent.service.core;
 import java.nio.file.FileSystemNotFoundException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -90,17 +91,24 @@ public class QueryTemplateService {
   }
 
   /**
-   * Generates a DELETE SPARQL query for a lifecycle occurrence constrained by its
-   * event type.
+   * Generates a DELETE SPARQL query for lifecycle occurrences constrained by
+   * their identifiers and event type.
    *
-   * @param resourceID  The target resource identifier for the instance.
-   * @param targetId    The target instance identifier.
-   * @param branchName  The branch name to filter (can be null).
+   * @param resourceID  The target resource identifier for the instances.
+   * @param targetIds   The target instance identifiers.
+   * @param branchName  The branch name to filter (must be null or blank).
    * @param optVarNames Set of names of optional variables.
    * @param eventType   The lifecycle event type IRI.
    */
-  public String genDeleteLifecycleOccurrenceQuery(String resourceID, String targetId, String branchName,
+  public String genDeleteLifecycleOccurrencesQuery(String resourceID, Collection<String> targetIds, String branchName,
       Set<String> optVarNames, String eventType) {
+    if (targetIds == null || targetIds.isEmpty()
+        || targetIds.stream().anyMatch(targetId -> targetId == null || targetId.isBlank())) {
+      throw new IllegalArgumentException("At least one lifecycle occurrence identifier is required!");
+    }
+    if (branchName != null && !branchName.isBlank()) {
+      throw new UnsupportedOperationException("Branch-specific lifecycle occurrence deletion is not implemented!");
+    }
     LOGGER.debug("Generating the lifecycle occurrence DELETE query with branchName = {}", branchName);
     ObjectNode addJsonSchema = this.getJsonLDResource(resourceID).deepCopy();
     JsonNode eventNode = addJsonSchema.path(LifecycleResource.EXEMPLIFIES_RELATIONS);
@@ -109,7 +117,8 @@ public class QueryTemplateService {
     }
     ((ObjectNode) eventNode).put(ShaclResource.ID_KEY, eventType);
     return this.deleteQueryTemplateFactory
-        .write(new QueryTemplateFactoryParameters(addJsonSchema, targetId, branchName, optVarNames))
+        .write(new QueryTemplateFactoryParameters(addJsonSchema, targetIds.stream().distinct().toList(), branchName,
+            optVarNames))
         .data();
   }
 

--- a/agent/src/main/java/com/cmclinnovations/agent/service/core/QueryTemplateService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/core/QueryTemplateService.java
@@ -3,7 +3,6 @@ package com.cmclinnovations.agent.service.core;
 import java.nio.file.FileSystemNotFoundException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -100,7 +99,7 @@ public class QueryTemplateService {
    * @param optVarNames Set of names of optional variables.
    * @param eventType   The lifecycle event type IRI.
    */
-  public String genDeleteLifecycleOccurrencesQuery(String resourceID, Collection<String> targetIds, String branchName,
+  public String genDeleteLifecycleOccurrencesBatchQuery(String resourceID, Set<String> targetIds, String branchName,
       Set<String> optVarNames, String eventType) {
     if (targetIds == null || targetIds.isEmpty()
         || targetIds.stream().anyMatch(targetId -> targetId == null || targetId.isBlank())) {
@@ -118,8 +117,7 @@ public class QueryTemplateService {
     }
     ((ObjectNode) eventNode).put(ShaclResource.ID_KEY, eventType);
     return this.deleteQueryTemplateFactory
-        .write(new QueryTemplateFactoryParameters(addJsonSchema, targetIds.stream().distinct().toList(), branchName,
-            optVarNames))
+        .write(new QueryTemplateFactoryParameters(addJsonSchema, targetIds, branchName, optVarNames))
         .data();
   }
 

--- a/agent/src/main/java/com/cmclinnovations/agent/service/core/QueryTemplateService.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/service/core/QueryTemplateService.java
@@ -111,6 +111,7 @@ public class QueryTemplateService {
     }
     LOGGER.debug("Generating the lifecycle occurrence DELETE query with branchName = {}", branchName);
     ObjectNode addJsonSchema = this.getJsonLDResource(resourceID).deepCopy();
+    // Constrain the shared delete template to the requested lifecycle event type.
     JsonNode eventNode = addJsonSchema.path(LifecycleResource.EXEMPLIFIES_RELATIONS);
     if (!eventNode.isObject()) {
       throw new IllegalArgumentException("Lifecycle occurrence JSON-LD must define an exemplifies relation!");

--- a/agent/src/main/java/com/cmclinnovations/agent/template/query/DeleteQueryTemplateFactory.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/template/query/DeleteQueryTemplateFactory.java
@@ -25,6 +25,7 @@ import com.cmclinnovations.agent.model.util.DataManifest;
 import com.cmclinnovations.agent.service.core.JsonLdService;
 import com.cmclinnovations.agent.utils.QueryResource;
 import com.cmclinnovations.agent.utils.ShaclResource;
+import com.cmclinnovations.agent.utils.StringResource;
 
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ArrayNode;
@@ -35,6 +36,7 @@ public class DeleteQueryTemplateFactory extends AbstractQueryTemplateFactory {
   private Map<String, String> anonymousVariableMappings;
   private Map<String, Queue<GraphPattern>> arrayPatternsMap;
   private final JsonLdService jsonLdService;
+  private static final String TARGET_ID_KEY = "target_id";
   private static final Logger LOGGER = LogManager.getLogger(DeleteQueryTemplateFactory.class);
 
   /**
@@ -56,10 +58,16 @@ public class DeleteQueryTemplateFactory extends AbstractQueryTemplateFactory {
   public DataManifest<String> write(QueryTemplateFactoryParameters params) {
     this.reset();
 
-    ModifyQuery deleteTemplate = this.genDeleteTemplate(params.targetIds().poll().get(0),
+    List<String> targetIds = params.targetIds().poll();
+    ModifyQuery deleteTemplate = this.genDeleteTemplate(targetIds,
         this.parseVariable((ObjectNode) params.rootNode().path(ShaclResource.ID_KEY)));
     this.recursiveParseNode(deleteTemplate, null, params.rootNode(), params.branchName(), params.optVarNames());
     String query = this.appendArrayStatements(deleteTemplate.getQueryString(), params.optVarNames());
+    if (targetIds.size() > 1) {
+      String targetIdValues = QueryResource.values(
+          targetIds.stream().map(targetId -> Rdf.literalOf(targetId).getQueryString()).toList(), TARGET_ID_KEY);
+      query = StringResource.replaceLast(query, "}", targetIdValues + "}");
+    }
     return new DataManifest<>(query, new ArrayList<>());
   }
 
@@ -71,12 +79,14 @@ public class DeleteQueryTemplateFactory extends AbstractQueryTemplateFactory {
   /**
    * Initialise a delete template.
    * 
-   * @param targetId The identifier of the instance to delete.
+   * @param targetIds The identifiers of the instances to delete.
    * @param idVar    The instance id as a variable.
    */
-  private ModifyQuery genDeleteTemplate(String targetId, Variable idVar) {
-    TriplePattern identifierTriple = idVar.has(QueryResource.DC_TERM_ID,
-        Rdf.literalOf(targetId));
+  private ModifyQuery genDeleteTemplate(List<String> targetIds, Variable idVar) {
+    RdfObject targetId = targetIds.size() == 1
+        ? Rdf.literalOf(targetIds.get(0))
+        : QueryResource.genVariable(TARGET_ID_KEY);
+    TriplePattern identifierTriple = idVar.has(QueryResource.DC_TERM_ID, targetId);
     return QueryResource.getDeleteQuery().delete(identifierTriple).where(identifierTriple);
   }
 

--- a/agent/src/main/java/com/cmclinnovations/agent/template/query/DeleteQueryTemplateFactory.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/template/query/DeleteQueryTemplateFactory.java
@@ -64,6 +64,7 @@ public class DeleteQueryTemplateFactory extends AbstractQueryTemplateFactory {
     this.recursiveParseNode(deleteTemplate, null, params.rootNode(), params.branchName(), params.optVarNames());
     String query = this.appendArrayStatements(deleteTemplate.getQueryString(), params.optVarNames());
     if (targetIds.size() > 1) {
+      // Bind the shared identifier variable to every requested target.
       String targetIdValues = QueryResource.values(
           targetIds.stream().map(targetId -> Rdf.literalOf(targetId).getQueryString()).toList(), TARGET_ID_KEY);
       query = StringResource.replaceLast(query, "}", targetIdValues + "}");

--- a/agent/src/main/java/com/cmclinnovations/agent/utils/LifecycleResource.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/utils/LifecycleResource.java
@@ -34,6 +34,11 @@ public class LifecycleResource {
   public static final String RECURRENCE_DAILY_TASK_STRING = "\"" + RECURRENCE_DAILY_TASK + "\"";
   public static final String RECURRENCE_ALT_DAY_TASK_STRING = "\"" + RECURRENCE_ALT_DAY_TASK + "\"";
   public static final String RECURRENCE_FIXED_DATE_TASK_STRING = "\"" + RECURRENCE_FIXED_DATE_TASK + "\"";
+  public static final String ORDER_INITIALISE_MESSAGE = "Order received and is being processed.";
+  public static final String ORDER_DISPATCH_MESSAGE = "Order has been assigned and is awaiting execution.";
+  public static final String ORDER_COMPLETE_MESSAGE = "Order has been completed successfully.";
+  public static final String ORDER_ACCRUAL_MESSAGE = "Billables have been accrued successfully.";
+  public static final String SERVICE_VOID_MESSAGE = "Service has been voided.";
 
   public static final String INSTANCE_KEY = "id_instance";
   public static final String CONTRACT_KEY = "contract";

--- a/agent/src/main/java/com/cmclinnovations/agent/utils/QueryResource.java
+++ b/agent/src/main/java/com/cmclinnovations/agent/utils/QueryResource.java
@@ -100,6 +100,7 @@ public class QueryResource {
     public static final String ACCOUNT_ID_KEY = "account";
     public static final Variable DATE_VAR = QueryResource.genVariable(LifecycleResource.DATE_KEY);
     public static final Variable EVENT_ID_VAR = QueryResource.genVariable(LifecycleResource.EVENT_ID_KEY);
+    public static final Variable PREVIOUS_EVENT_TYPE_VAR = QueryResource.genVariable("previous_event_type");
     public static final ColumnMetaPayload EVENT_ID_COL = new ColumnMetaPayload(QueryResource.EVENT_ID_VAR.getVarName(),
             QueryResource.LITERAL_TYPE, ShaclResource.XSD_STRING);
     public static final Variable EVENT_STATUS_VAR = QueryResource.genVariable(LifecycleResource.EVENT_STATUS_KEY);

--- a/agent/src/main/resources/query/get/lifecycle/contract_prev_event.sparql
+++ b/agent/src/main/resources/query/get/lifecycle/contract_prev_event.sparql
@@ -3,10 +3,13 @@ PREFIX dc-terms: <http://purl.org/dc/terms/>
 PREFIX fibo-fnd-rel-rel: <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-SELECT DISTINCT ?iri ?id
+SELECT DISTINCT ?source_id ?previous_event_type ?iri ?id
 WHERE {
-  ?event dc-terms:identifier "[target]" ;
+  VALUES ?source_id { [target] }
+  VALUES ?previous_event_type { [target] }
+
+  ?event dc-terms:identifier ?source_id ;
     cmns-dt:succeeds* ?iri .
   ?iri dc-terms:identifier ?id ;
-    fibo-fnd-rel-rel:exemplifies <[target]> .
+    fibo-fnd-rel-rel:exemplifies ?previous_event_type .
 }

--- a/agent/src/main/resources/query/get/lifecycle/contract_prev_event.sparql
+++ b/agent/src/main/resources/query/get/lifecycle/contract_prev_event.sparql
@@ -3,12 +3,12 @@ PREFIX dc-terms: <http://purl.org/dc/terms/>
 PREFIX fibo-fnd-rel-rel: <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-SELECT DISTINCT ?source_id ?previous_event_type ?iri ?id
+SELECT DISTINCT ?event_id ?previous_event_type ?iri ?id
 WHERE {
-  VALUES ?source_id { [target] }
+  VALUES ?event_id { [target] }
   VALUES ?previous_event_type { [target] }
 
-  ?event dc-terms:identifier ?source_id ;
+  ?event dc-terms:identifier ?event_id ;
     cmns-dt:succeeds* ?iri .
   ?iri dc-terms:identifier ?id ;
     fibo-fnd-rel-rel:exemplifies ?previous_event_type .

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.64.4";
+  private static final String API_VERSION = "1.65.0-batch-bulk-assign-SNAPSHOT";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
+++ b/agent/src/test/java/com/cmclinnovations/agent/AgentApplicationTests.java
@@ -25,7 +25,7 @@ class AgentApplicationTests {
   @Autowired
   private MockMvc mockMvc;
 
-  private static final String API_VERSION = "1.65.0-batch-bulk-assign-SNAPSHOT";
+  private static final String API_VERSION = "1.65.0";
   private static final String STATUS_MESSAGE_EN = "Agent is ready to receive requests.";
   private static final String STATUS_MESSAGE_DE = "Agent ist bereit, Anfragen zu empfangen.";
   private static final String INVALID_GEOCODING_MESSAGE_EN = "Invalid geocoding parameters! Detected a block number but no street is provided!";

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.64.4
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.65.0-batch-bulk-assign-SNAPSHOT
     build:
       context: ..
       target: test

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent-test
-    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.65.0-batch-bulk-assign-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent-test:1.65.0
     build:
       context: ..
       target: test

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.65.0-batch-bulk-assign-SNAPSHOT
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.65.0
     build:
       context: ..
       target: agent

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   agent:
     container_name: vis-backend-agent
-    image: ghcr.io/theworldavatar/vis-backend-agent:1.64.4
+    image: ghcr.io/theworldavatar/vis-backend-agent:1.65.0-batch-bulk-assign-SNAPSHOT
     build:
       context: ..
       target: agent

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.65.0-batch-bulk-assign-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.65.0",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent-debug.json
+++ b/docker/vis-backend-agent-debug.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.64.4",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.65.0-batch-bulk-assign-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.65.0-batch-bulk-assign-SNAPSHOT",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.65.0",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",

--- a/docker/vis-backend-agent.json
+++ b/docker/vis-backend-agent.json
@@ -3,7 +3,7 @@
     "Name": "vis-backend-agent",
     "TaskTemplate": {
       "ContainerSpec": {
-        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.64.4",
+        "Image": "ghcr.io/theworldavatar/vis-backend-agent:1.65.0-batch-bulk-assign-SNAPSHOT",
         "Env": [
           "REDIS=redis://<STACK>-redis:6379",
           "KEYCLOAK_ISSUER_URI=http://<DOMAIN>/realms/<REALM>",


### PR DESCRIPTION
Updated bulk assignment and reassignment of service tasks to perform the following steps in batches:
- Retrieve all previous occurrences
- Delete existing dispatch occurrences
-  Instantiate dispatch occurrences
- Record activity logs

These operations remain in series for now:
- Retrieve lifecycle stages of contract: this is negligible in terms of time cost
- SHACL rule processing: this shall be addressed in a separate pull request